### PR TITLE
feat: align terraform refresh configuration

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -20,3 +20,4 @@ jobs:
         run: |
           node tests/test-comment-length.js
           node tests/test-backtick-escaping.js
+          node tests/test-refresh-configuration.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v2.0.0] - Unreleased
+## [v2.0.0] - 2026-04-16
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v2.0.0] - Unreleased
+
+### Changed
+
+- Added the `refresh` input to `terraform-plan` and `terraform-plan-gcp`.
+- Changed standalone plan actions to use `-refresh=${{ inputs.refresh }}` with a default of `true`, matching the apply actions.
+
+### Warning
+
+- `v1.1.4` changed AWS `terraform-apply` from always using `-refresh=false` to a configurable `refresh` input with a default of `true`; the GCP apply action also defaults `refresh` to `true` in the current `v1` line. Because `v1` is a moving tag, workflows using `@v1` may have already picked up that behavior. If you need the old no-refresh behavior, set `refresh: 'false'` explicitly or pin to `v1.1.3` while you plan the migration.
+- Publish this change as a major release and move consumers to `@v2` once plan/apply refresh behavior is reviewed for each environment.
+
 ## [v1.1.7] - 2026-03-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repository provides a collection of reusable composite GitHub Actions for managing Terraform operations (`plan`, `apply`, etc.) across different environments (`dev`, `prod`, `stage`, etc.). These actions are designed to integrate with AWS and securely manage secrets.
 
+## Version Warning
+
+`v1.1.4` changed the AWS `terraform-apply` action from always running with `-refresh=false` to using the `refresh` input with a default of `true`; the GCP apply action also defaults `refresh` to `true` in the current `v1` line. Because `v1` is a moving tag, workflows using `@v1` may already run apply with refresh enabled.
+
+If your workflows rely on the old no-refresh behavior, set `refresh: 'false'` explicitly or pin to `v1.1.3` while you review the migration. Use `@v2` for the major release where plan and apply actions expose the same refresh configuration.
+
 ## Available Composite Actions
 
 ### 1. `pull-request` (Terraform Plan)

--- a/actions/terraform-apply-gcp/README.md
+++ b/actions/terraform-apply-gcp/README.md
@@ -17,13 +17,15 @@ Here are the inputs the workflow requires:
 | `slack_webhook_url`              | The Slack Webhook URL for posting deployment notifications | `false`  | `''`    |
 | `terraform_version`              | Terraform version to use                                   | `false`  | `1.8.4` |
 | `working_dir`                    | The working directory for Terraform files                  | `true`   |         |
+| `refresh`                        | Whether to refresh state before planning and applying      | `false`  | `true`  |
+| `github_token`                   | GitHub Token to post comments to PR                        | `false`  | `''`    |
 
 ## Usage
 
 ```
 steps:
   - name: Run Terraform Apply
-    uses: c0x12c/gh-actions-terraform-workflows/actions/terraform-apply-gcp@v1
+    uses: c0x12c/gh-actions-terraform-workflows/actions/terraform-apply-gcp@v2
     with:
       gcp_project_id: 'my-project-id'
       gcp_service_account: 'my-service-account'
@@ -34,4 +36,6 @@ steps:
       slack_webhook_url: 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
       terraform_version: '0.14.5'
       working_dir: './terraform'
+      refresh: 'true'
+      github_token: 'github-token'
 ```

--- a/actions/terraform-apply/README.md
+++ b/actions/terraform-apply/README.md
@@ -16,13 +16,14 @@ Here are the inputs the workflow requires:
 | `slack_webhook_url` | The Slack Webhook URL for posting deployment notifications | `false`  | `''`    |
 | `terraform_version` | Terraform version to use                                   | `false`  | `1.8.4` |
 | `working_dir`       | The working directory for Terraform files                  | `true`   |         |
+| `refresh`           | Whether to refresh state before applying                   | `false`  | `true`  |
 
 ## Usage
 
 ```
 steps:
   - name: Run Terraform Apply
-    uses: c0x12c/gh-actions-terraform-workflows/actions/terraform-apply@v1
+    uses: c0x12c/gh-actions-terraform-workflows/actions/terraform-apply@v2
     with:
       aws_region: 'us-east-1'
       aws_role: 'arn:aws:iam::123456789012:role/my-role'
@@ -32,4 +33,5 @@ steps:
       slack_webhook_url: 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
       terraform_version: '0.14.5'
       working_dir: './terraform'
+      refresh: 'true'
 ```

--- a/actions/terraform-plan-gcp/README.md
+++ b/actions/terraform-plan-gcp/README.md
@@ -17,6 +17,7 @@ Here are the required inputs for the workflow:
 | `secret_filter`                  | The filter name to use with git-secret-protector  | `false`  | `''`    |
 | `terraform_version`              | The Terraform version to use                      | `false`  | `1.8.4` |
 | `working_dir`                    | Working directory for Terraform files             | `true`   |         |
+| `refresh`                        | Whether to refresh state before planning          | `false`  | `true`  |
 
 ## Usage
 
@@ -25,7 +26,7 @@ Here is an example of how to use this workflow in your GitHub actions:
 ```
 steps:
   - name: Run Terraform Plan
-    uses: c0x12c/gh-actions-terraform-workflows/actions/terraform-plan-gcp@v1
+    uses: c0x12c/gh-actions-terraform-workflows/actions/terraform-plan-gcp@v2
     with:
       gcp_project_id: 'my-project-id'
       gcp_service_account: 'my-service-account
@@ -36,6 +37,7 @@ steps:
       secret_filter: 'my-secret-filter'
       terraform_version: '1.8.4'
       working_dir: './terraform'
+      refresh: 'true'
 ```
 
 Add sample for Terraform Plan workflow

--- a/actions/terraform-plan-gcp/action.yml
+++ b/actions/terraform-plan-gcp/action.yml
@@ -32,6 +32,10 @@ inputs:
   working_dir:
     description: "The working directory for Terraform files"
     required: true
+  refresh:
+    description: "Whether to refresh the state before planning (true/false)"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -88,7 +92,7 @@ runs:
       id: plan
       shell: bash
       run: |
-        terraform plan -input=false -no-color -lock=false -refresh=false -out=/tmp/plan.tmp
+        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out=/tmp/plan.tmp
         terraform show -no-color /tmp/plan.tmp > /tmp/plan.out
         rm -f /tmp/plan.tmp
       continue-on-error: true

--- a/actions/terraform-plan/README.md
+++ b/actions/terraform-plan/README.md
@@ -16,6 +16,7 @@ Here are the required inputs for the workflow:
 | `secret_filter`     | The filter name to use with git-secret-protector | `false`  | `''`    |
 | `terraform_version` | The Terraform version to use                     | `false`  | `1.8.4` |
 | `working_dir`       | Working directory for Terraform files            | `true`   |         |
+| `refresh`           | Whether to refresh state before planning         | `false`  | `true`  |
 
 ## Usage
 
@@ -24,7 +25,7 @@ Here is an example of how to use this workflow in your GitHub actions:
 ```
 steps:
   - name: Run Terraform Plan
-    uses: c0x12c/gh-actions-terraform-workflows/actions/terraform-plan@v1
+    uses: c0x12c/gh-actions-terraform-workflows/actions/terraform-plan@v2
     with:
       aws_region: 'us-east-1'
       aws_role: 'arn:aws:iam::123456789012:role/my-role'
@@ -34,4 +35,5 @@ steps:
       secret_filter: 'my-secret-filter'
       terraform_version: '1.8.4'
       working_dir: './terraform'
+      refresh: 'true'
 ```

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -29,6 +29,10 @@ inputs:
   working_dir:
     description: "The working directory for Terraform files"
     required: true
+  refresh:
+    description: "Whether to refresh the state before planning (true/false)"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -83,7 +87,7 @@ runs:
       id: plan
       shell: bash
       run: |
-        terraform plan -input=false -no-color -lock=false -refresh=false -out=/tmp/plan.tmp
+        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out=/tmp/plan.tmp
         terraform show -no-color /tmp/plan.tmp > /tmp/plan.out
         rm -f /tmp/plan.tmp
       continue-on-error: true

--- a/tests/test-refresh-configuration.js
+++ b/tests/test-refresh-configuration.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function readAction(actionPath) {
+  return fs.readFileSync(path.join(ROOT, actionPath), 'utf8');
+}
+
+function assertHasRefreshInput(actionPath, expectedDescriptionFragment) {
+  const action = readAction(actionPath);
+
+  assert.match(action, /^  refresh:\n/m, `${actionPath} should define a refresh input`);
+  assert.match(
+    action,
+    new RegExp(`description: "${expectedDescriptionFragment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+    `${actionPath} should describe what refresh controls`,
+  );
+  assert.match(action, /required: false\n    default: "true"/, `${actionPath} should default refresh to true`);
+}
+
+function assertTerraformCommandUsesRefresh(actionPath, command) {
+  const action = readAction(actionPath);
+
+  assert.match(
+    action,
+    new RegExp(`${command}[^\\n]*-refresh=\\$\\{\\{ inputs\\.refresh \\}\\}`),
+    `${actionPath} should pass inputs.refresh to terraform ${command}`,
+  );
+}
+
+function runTests() {
+  console.log('Running refresh configuration tests...\n');
+
+  assertHasRefreshInput('actions/terraform-plan/action.yml', 'Whether to refresh the state before planning');
+  assertTerraformCommandUsesRefresh('actions/terraform-plan/action.yml', 'terraform plan');
+
+  assertHasRefreshInput('actions/terraform-plan-gcp/action.yml', 'Whether to refresh the state before planning');
+  assertTerraformCommandUsesRefresh('actions/terraform-plan-gcp/action.yml', 'terraform plan');
+
+  assertHasRefreshInput('actions/terraform-apply/action.yml', 'Whether to refresh the state before applying');
+  assertTerraformCommandUsesRefresh('actions/terraform-apply/action.yml', 'terraform apply');
+
+  assertHasRefreshInput('actions/terraform-apply-gcp/action.yml', 'Whether to refresh the state before applying');
+  assertTerraformCommandUsesRefresh('actions/terraform-apply-gcp/action.yml', 'terraform plan');
+  assertTerraformCommandUsesRefresh('actions/terraform-apply-gcp/action.yml', 'terraform apply');
+
+  console.log('All refresh configuration tests passed.');
+}
+
+runTests();


### PR DESCRIPTION
## Summary

Align Terraform refresh handling across reusable plan/apply actions and prepare this as a v2.0.0 major release.

### Why

The current v1 line is dangerous because plan actions hard-code `-refresh=false`, while apply actions default `refresh` to `true`. The AWS apply default changed inside the v1 line, so users on the moving `@v1` tag may already apply with refresh enabled unexpectedly.

### What

- Add `refresh` input to AWS and GCP standalone plan actions.
- Use `-refresh=${{ inputs.refresh }}` in standalone plan commands with default `true`, matching apply actions.
- Document `refresh` across plan/apply READMEs and switch examples to `@v2`.
- Add v1 warning and v2.0.0 changelog entry.
- Add a refresh configuration regression test and run it in PR checks.

### Solution

This makes refresh behavior explicit for plan and apply users. It treats the default-refresh alignment as a major release change, while documenting how v1 consumers can keep no-refresh behavior by setting `refresh: false` explicitly or pinning to `v1.1.3` during migration.

## Types of Changes

- [x] Breaking change
- [x] New feature
- [x] Documentation
- [x] Test

## Test Plan

- [x] `node tests/test-comment-length.js`
- [x] `node tests/test-backtick-escaping.js`
- [x] `node tests/test-refresh-configuration.js`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested that the feature or bug fix works as expected
- [x] I have added tests that prove my changes are functioning
- [x] New and existing unit tests pass locally with my changes

## Related Issues

N/A