### PR TITLE
feat(terraform-apply): add role_duration_seconds input for long-running applies

### DIFF
--- a/actions/terraform-apply/action.yml
+++ b/actions/terraform-apply/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Whether to refresh the state before applying (true/false)"
     required: false
     default: "true"
+  role_duration_seconds:
+    description: "STS session TTL in seconds for the assumed AWS role. Bump when apply can run longer than the role default (e.g. MSK reconfigurations that take 30-60 min). Capped by the IAM role's MaxSessionDuration."
+    required: false
+    default: "3600"
 
 runs:
   using: "composite"
@@ -64,6 +68,7 @@ runs:
         role-to-assume: ${{ inputs.aws_role }}
         role-session-name: gh-actions
         aws-region: ${{ inputs.aws_region }}
+        role-duration-seconds: ${{ inputs.role_duration_seconds }}
 
     - name: Decrypt Secrets
       if: ${{ inputs.secret_filter != '' }}


### PR DESCRIPTION
## Summary

Default OIDC STS session = 1h. When \`terraform apply\` triggers a long-running mutation (e.g. MSK \`UpdateBrokerType\` + \`UpdateSecurity\` rolling restart that takes 60+ min), the token expires mid-apply and every subsequent AWS API call returns 403 \`ExpiredTokenException\`.

Concrete cascade observed in downstream \`8Fleet-LA/infra-terraform\` v0.4.1:

\`\`\`
Error: waiting for MSK Cluster ... DescribeClusterOperation
  StatusCode: 403, ExpiredTokenException
Error: Failed to save state ... S3: PutObject
  StatusCode: 400, api error ExpiredToken
Error: Failed to release the state lock ... S3: GetObject
  StatusCode: 400, api error ExpiredToken
  → state lock STUCK, requires manual force-unlock + state recovery
\`\`\`

## Fix

Add \`role_duration_seconds\` input, thread it through to the underlying \`aws-actions/configure-aws-credentials\` step.

## Non-breaking

Default stays at \`3600\` (1h) so existing consumers see no behavior change. Consumers can opt in by passing a higher value (e.g. \`14400\` for 4h).

## Caveat for consumers

The assumed role's \`MaxSessionDuration\` must be at least the requested \`role_duration_seconds\`. AWS rejects the \`AssumeRoleWithWebIdentity\` call with \`ValidationError\` otherwise.

## Tag plan

Please cut \`v1.1.8\` after merge so downstreams can pin without chasing master.