### PR TITLE
feat(terraform-plan)!: sticky PR comments, on by default

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,3 +21,4 @@ jobs:
           node tests/test-comment-length.js
           node tests/test-backtick-escaping.js
           node tests/test-refresh-configuration.js
+          node tests/test-sticky-comment.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [v3.0.0] - 2026-07-25
 
 ### Added
 
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Warning
 
-- `comment_mode` defaults to `sticky`, which is a behavior change: consumers on the default will see one plan comment per environment updated in place instead of an accumulating thread. Set `comment_mode: 'new'` to keep the previous append-on-every-run behavior. Publish this as a **major release** and move consumers to the new `@v3` tag once the sticky behavior is reviewed.
+- `comment_mode` defaults to `sticky`, which is a behavior change: consumers on the default will see one plan comment per environment updated in place instead of an accumulating thread. This is why the release is a **major bump** (`v3.0.0`). Consumers pinned to `@v2` are unaffected until they move to `@v3`; to keep the previous append-on-every-run behavior after upgrading, set `comment_mode: 'new'`.
 
 ## [v2.0.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `terraform-plan`: `comment_mode` input (`sticky` | `new`). In `sticky` mode a single plan comment per plan is updated in place instead of a new comment being posted on every run.
+- `terraform-plan`: `comment_marker` input identifying the sticky comment. Left empty it derives `<!-- terraform-plan:<environment>:<working_dir> -->`, so concurrent plans on the same PR keep separate comments.
+- `terraform-plan`: `pr_number` input so a `workflow_dispatch`-driven plan can post a comment on a specific PR.
+
+### Changed
+
+- `terraform-plan`: `comment_mode` defaults to `sticky`. Plan comments now update in place rather than accumulating.
+- `terraform-plan`: consumer-controlled values are passed to the comment script through the step environment instead of being interpolated into it, and the sticky comment listing is paginated at 100 so the marker is not missed on a busy PR.
+
+### Fixed
+
+- `terraform-plan`: removed a "Terraform Format and Style" line that always rendered empty (it read `steps.fmt.outcome`, but the action has no `fmt` step).
+- `terraform-plan`: the truncation notice now reports the number of characters actually shown rather than the pre-notice budget, and the "output too large" fallback is no longer indented into a markdown code block.
+- `terraform-plan`: `pr_number` is validated, a multi-line `comment_marker` is rejected, and backtick-bearing metadata is escaped so it cannot break out of its inline code span.
+
+### Warning
+
+- `comment_mode` defaults to `sticky`, which is a behavior change: consumers on the default will see one plan comment per environment updated in place instead of an accumulating thread. Set `comment_mode: 'new'` to keep the previous append-on-every-run behavior. Publish this as a **major release** and move consumers to the new `@v3` tag once the sticky behavior is reviewed.
+
 ## [v2.0.0] - 2026-04-16
 
 ### Changed

--- a/actions/terraform-plan/README.md
+++ b/actions/terraform-plan/README.md
@@ -17,6 +17,34 @@ Here are the required inputs for the workflow:
 | `terraform_version` | The Terraform version to use                     | `false`  | `1.8.4` |
 | `working_dir`       | Working directory for Terraform files            | `true`   |         |
 | `refresh`           | Whether to refresh state before planning         | `false`  | `true`  |
+| `comment_mode`      | `new` posts a fresh comment each run; `sticky` updates one in place | `false` | `new` |
+| `comment_marker`    | Hidden marker identifying the sticky comment (sticky mode only) | `false` | derived from `environment` + `working_dir` |
+| `pr_number`         | PR to comment on; defaults to the triggering event's PR | `false` | `''` |
+
+## Sticky comments
+
+By default each run adds a new plan comment. On a PR that runs several plans - multiple
+environments, or multiple Terraform roots - that becomes a new comment per plan per push.
+
+Set `comment_mode: sticky` to keep a single comment per plan, updated in place:
+
+```yaml
+  - name: Run Terraform Plan
+    uses: c0x12c/gh-actions-terraform-workflows/actions/terraform-plan@v2
+    with:
+      # ...
+      environment: 'staging'
+      working_dir: './terraform'
+      comment_mode: 'sticky'
+```
+
+Each sticky comment is identified by a hidden HTML marker embedded in its body. The default
+marker is derived from `environment` and `working_dir`, so concurrent plans on the same PR
+keep their own comments instead of overwriting each other. Override it with `comment_marker`
+if you need a different grouping.
+
+Commenting normally requires a `pull_request` event. To comment from a `workflow_dispatch`
+run, pass the target PR explicitly with `pr_number`.
 
 ## Usage
 

--- a/actions/terraform-plan/README.md
+++ b/actions/terraform-plan/README.md
@@ -17,31 +17,30 @@ Here are the required inputs for the workflow:
 | `terraform_version` | The Terraform version to use                     | `false`  | `1.8.4` |
 | `working_dir`       | Working directory for Terraform files            | `true`   |         |
 | `refresh`           | Whether to refresh state before planning         | `false`  | `true`  |
-| `comment_mode`      | `new` posts a fresh comment each run; `sticky` updates one in place | `false` | `new` |
+| `comment_mode`      | `sticky` updates one comment in place; `new` appends a fresh comment each run | `false` | `sticky` |
 | `comment_marker`    | Hidden marker identifying the sticky comment (sticky mode only) | `false` | derived from `environment` + `working_dir` |
 | `pr_number`         | PR to comment on; defaults to the triggering event's PR | `false` | `''` |
 
 ## Sticky comments
 
-By default each run adds a new plan comment. On a PR that runs several plans - multiple
-environments, or multiple Terraform roots - that becomes a new comment per plan per push.
+Plan comments are **sticky by default**: one comment per plan, updated in place on every
+run. On a PR that runs several plans - multiple environments, or multiple Terraform roots -
+appending instead would add a new comment per plan per push and bury the discussion.
 
-Set `comment_mode: sticky` to keep a single comment per plan, updated in place:
+Each sticky comment is identified by a hidden HTML marker in its body. Left unset,
+`comment_marker` derives `<!-- terraform-plan:<environment>:<working_dir> -->`, so
+concurrent plans on the same PR keep their own comments instead of overwriting each other.
+Set it explicitly to group them differently.
+
+To get the old append-on-every-run behaviour instead:
 
 ```yaml
   - name: Run Terraform Plan
     uses: c0x12c/gh-actions-terraform-workflows/actions/terraform-plan@v2
     with:
       # ...
-      environment: 'staging'
-      working_dir: './terraform'
-      comment_mode: 'sticky'
+      comment_mode: 'new'
 ```
-
-Each sticky comment is identified by a hidden HTML marker embedded in its body. The default
-marker is derived from `environment` and `working_dir`, so concurrent plans on the same PR
-keep their own comments instead of overwriting each other. Override it with `comment_marker`
-if you need a different grouping.
 
 Commenting normally requires a `pull_request` event. To comment from a `workflow_dispatch`
 run, pass the target PR explicitly with `pr_number`.

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -35,17 +35,19 @@ inputs:
     default: "true"
   comment_mode:
     description: >-
-      How to post the plan comment. "new" (default) adds a fresh comment on every run.
-      "sticky" updates a single comment in place, keyed by comment_marker - use this when a
-      PR runs several plans (multiple environments or working directories) to avoid a new
-      comment per environment per push.
+      How to post the plan comment. "sticky" (default) keeps one comment per plan and
+      updates it in place, so repeated pushes do not bury the PR under a comment per
+      environment per run. Set "new" to append a fresh comment on every run instead.
     required: false
-    default: "new"
+    default: "sticky"
   comment_marker:
     description: >-
       Hidden HTML marker identifying the sticky comment to update. Only used when
-      comment_mode is "sticky". Defaults to a marker derived from environment and
-      working_dir, which keeps concurrent plans on the same PR in separate comments.
+      comment_mode is "sticky". Left empty it derives
+      "<!-- terraform-plan:<environment>:<working_dir> -->", which keeps concurrent plans on
+      the same PR in separate comments; set it explicitly to group them differently. It
+      cannot be defaulted literally here because the inputs context is unavailable when
+      GitHub evaluates input defaults.
     required: false
     default: ""
   pr_number:
@@ -202,7 +204,18 @@ runs:
             output = `${baseHeader}${plan}${baseFooter}`;
           }
 
-          const issue_number = Number('${{ inputs.pr_number }}') || context.issue.number;
+          // Fail loudly on a malformed pr_number rather than silently falling back to the
+          // event's PR, which would post the plan onto the wrong pull request.
+          const rawPrNumber = '${{ inputs.pr_number }}'.trim();
+          let issue_number;
+          if (rawPrNumber !== '') {
+            issue_number = Number(rawPrNumber);
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              throw new Error(`pr_number must be a positive integer, got "${rawPrNumber}"`);
+            }
+          } else {
+            issue_number = context.issue.number;
+          }
           const { owner, repo } = context.repo;
 
           if (sticky) {
@@ -211,7 +224,10 @@ runs:
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number, per_page: 100,
             });
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            // Match the marker as the comment's first line, not anywhere in the body: the
+            // plan text is embedded verbatim, so a substring match could latch onto an
+            // unrelated comment that merely quotes the marker.
+            const existing = comments.find((c) => c.body && c.body.split('\n')[0].trim() === marker);
             if (existing) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: output });
               return;

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -126,6 +126,21 @@ runs:
     - name: Post Terraform Plan Results to PR
       uses: actions/github-script@v8
       if: ${{ github.event_name == 'pull_request' || inputs.pr_number != '' }}
+      env:
+        # Passed as environment variables rather than interpolated into the script body: a
+        # value containing a quote would otherwise produce invalid JavaScript, and inputs
+        # are consumer-controlled, so interpolating them is a script-injection vector.
+        PLAN_ENVIRONMENT: ${{ inputs.environment }}
+        PLAN_WORKING_DIR: ${{ inputs.working_dir }}
+        PLAN_COMMENT_MODE: ${{ inputs.comment_mode }}
+        PLAN_COMMENT_MARKER: ${{ inputs.comment_marker }}
+        PLAN_PR_NUMBER: ${{ inputs.pr_number }}
+        PLAN_INIT_OUTCOME: ${{ steps.init.outcome }}
+        PLAN_VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
+        PLAN_PLAN_OUTCOME: ${{ steps.plan.outcome }}
+        PLAN_ACTOR: ${{ github.actor }}
+        PLAN_EVENT_NAME: ${{ github.event_name }}
+        PLAN_WORKFLOW: ${{ github.workflow }}
       with:
         github-token: ${{ inputs.github_token }}
         script: |
@@ -137,21 +152,26 @@ runs:
           let plan = fs.readFileSync('/tmp/plan.out', 'utf8').replace(/`/g, '\\`')
           fs.unlinkSync('/tmp/plan.out')
 
-          const environment = '${{ inputs.environment }}'.toUpperCase()
+          const environment = process.env.PLAN_ENVIRONMENT.toUpperCase()
+          const workingDir = process.env.PLAN_WORKING_DIR
+          const initOutcome = process.env.PLAN_INIT_OUTCOME
+          const validateOutcome = process.env.PLAN_VALIDATE_OUTCOME
+          const planOutcome = process.env.PLAN_PLAN_OUTCOME
 
-          const sticky = '${{ inputs.comment_mode }}' === 'sticky';
-          // Default keeps concurrent plans on one PR in separate comments (a PR that plans
-          // several environments or roots would otherwise fight over a single comment).
-          const marker = '${{ inputs.comment_marker }}' ||
-            `<!-- terraform-plan:${{ inputs.environment }}:${{ inputs.working_dir }} -->`;
+          const sticky = process.env.PLAN_COMMENT_MODE === 'sticky';
+          // Trimmed so an accidentally padded marker still matches. The default keeps
+          // concurrent plans on one PR in separate comments (a PR that plans several
+          // environments or roots would otherwise fight over a single comment).
+          const marker = (process.env.PLAN_COMMENT_MARKER || '').trim() ||
+            `<!-- terraform-plan:${process.env.PLAN_ENVIRONMENT}:${workingDir} -->`;
 
           // GitHub comment body limit is 65536 characters
           const MAX_COMMENT_LENGTH = 65536
 
           // Calculate the base template size (without the plan content)
           const baseHeader = `${sticky ? marker + '\n' : ''}#### Environment: ${environment}
-          #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-          #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+          #### Terraform Initialization ⚙️\`${initOutcome}\`
+          #### Terraform Validation 🤖\`${validateOutcome}\`
           <details><summary>Validation Output</summary>
 
           \`\`\`\n
@@ -160,7 +180,7 @@ runs:
 
           </details>
 
-          #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+          #### Terraform Plan 📖\`${planOutcome}\`
 
           <details><summary>Show Plan</summary>
 
@@ -172,7 +192,7 @@ runs:
 
           </details>
 
-          *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ inputs.working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+          *Pusher: @${process.env.PLAN_ACTOR}, Action: \`${process.env.PLAN_EVENT_NAME}\`, Working Directory: \`${workingDir}\`, Workflow: \`${process.env.PLAN_WORKFLOW}\`*`;
 
           const baseLength = baseHeader.length + baseFooter.length;
           let output;
@@ -194,11 +214,11 @@ runs:
             } else {
               output = `${sticky ? marker + '\n' : ''}#### Environment: ${environment}
 
-          #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+          #### Terraform Plan 📖\`${planOutcome}\`
 
           Plan output is too large to display. Please check the workflow logs for the full plan.
 
-          *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ inputs.working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+          *Pusher: @${process.env.PLAN_ACTOR}, Action: \`${process.env.PLAN_EVENT_NAME}\`, Working Directory: \`${workingDir}\`, Workflow: \`${process.env.PLAN_WORKFLOW}\`*`;
             }
           } else {
             output = `${baseHeader}${plan}${baseFooter}`;
@@ -206,7 +226,7 @@ runs:
 
           // Fail loudly on a malformed pr_number rather than silently falling back to the
           // event's PR, which would post the plan onto the wrong pull request.
-          const rawPrNumber = '${{ inputs.pr_number }}'.trim();
+          const rawPrNumber = (process.env.PLAN_PR_NUMBER || '').trim();
           let issue_number;
           if (rawPrNumber !== '') {
             issue_number = Number(rawPrNumber);

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -164,6 +164,15 @@ runs:
           // environments or roots would otherwise fight over a single comment).
           const marker = (process.env.PLAN_COMMENT_MARKER || '').trim() ||
             `<!-- terraform-plan:${process.env.PLAN_ENVIRONMENT}:${workingDir} -->`;
+          // The sticky comment is matched on its first line, so a multi-line marker could
+          // never match and would silently post a new comment on every run.
+          if (sticky && /[\r\n]/.test(marker)) {
+            throw new Error('comment_marker must be a single line');
+          }
+
+          // These render inside inline-code spans; an embedded backtick would break out of
+          // the span and mangle the comment, so escape them like the plan output.
+          const inline = (v) => String(v ?? '').replace(/`/g, '\\`');
 
           // GitHub comment body limit is 65536 characters
           const MAX_COMMENT_LENGTH = 65536
@@ -192,7 +201,7 @@ runs:
 
           </details>
 
-          *Pusher: @${process.env.PLAN_ACTOR}, Action: \`${process.env.PLAN_EVENT_NAME}\`, Working Directory: \`${workingDir}\`, Workflow: \`${process.env.PLAN_WORKFLOW}\`*`;
+          *Pusher: @${process.env.PLAN_ACTOR}, Action: \`${inline(process.env.PLAN_EVENT_NAME)}\`, Working Directory: \`${inline(workingDir)}\`, Workflow: \`${inline(process.env.PLAN_WORKFLOW)}\`*`;
 
           const baseLength = baseHeader.length + baseFooter.length;
           let output;
@@ -218,7 +227,7 @@ runs:
 
           Plan output is too large to display. Please check the workflow logs for the full plan.
 
-          *Pusher: @${process.env.PLAN_ACTOR}, Action: \`${process.env.PLAN_EVENT_NAME}\`, Working Directory: \`${workingDir}\`, Workflow: \`${process.env.PLAN_WORKFLOW}\`*`;
+          *Pusher: @${process.env.PLAN_ACTOR}, Action: \`${inline(process.env.PLAN_EVENT_NAME)}\`, Working Directory: \`${inline(workingDir)}\`, Workflow: \`${inline(process.env.PLAN_WORKFLOW)}\`*`;
             }
           } else {
             output = `${baseHeader}${plan}${baseFooter}`;

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -33,6 +33,27 @@ inputs:
     description: "Whether to refresh the state before planning (true/false)"
     required: false
     default: "true"
+  comment_mode:
+    description: >-
+      How to post the plan comment. "new" (default) adds a fresh comment on every run.
+      "sticky" updates a single comment in place, keyed by comment_marker - use this when a
+      PR runs several plans (multiple environments or working directories) to avoid a new
+      comment per environment per push.
+    required: false
+    default: "new"
+  comment_marker:
+    description: >-
+      Hidden HTML marker identifying the sticky comment to update. Only used when
+      comment_mode is "sticky". Defaults to a marker derived from environment and
+      working_dir, which keeps concurrent plans on the same PR in separate comments.
+    required: false
+    default: ""
+  pr_number:
+    description: >-
+      PR number to comment on. Defaults to the PR from the triggering event; set it
+      explicitly so a workflow_dispatch-driven plan can still post a comment.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -102,7 +123,7 @@ runs:
 
     - name: Post Terraform Plan Results to PR
       uses: actions/github-script@v8
-      if: github.event_name == 'pull_request'
+      if: ${{ github.event_name == 'pull_request' || inputs.pr_number != '' }}
       with:
         github-token: ${{ inputs.github_token }}
         script: |
@@ -116,12 +137,17 @@ runs:
 
           const environment = '${{ inputs.environment }}'.toUpperCase()
 
+          const sticky = '${{ inputs.comment_mode }}' === 'sticky';
+          // Default keeps concurrent plans on one PR in separate comments (a PR that plans
+          // several environments or roots would otherwise fight over a single comment).
+          const marker = '${{ inputs.comment_marker }}' ||
+            `<!-- terraform-plan:${{ inputs.environment }}:${{ inputs.working_dir }} -->`;
+
           // GitHub comment body limit is 65536 characters
           const MAX_COMMENT_LENGTH = 65536
 
           // Calculate the base template size (without the plan content)
-          const baseHeader = `#### Environment: ${environment}
-          #### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+          const baseHeader = `${sticky ? marker + '\n' : ''}#### Environment: ${environment}
           #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
           #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
           <details><summary>Validation Output</summary>
@@ -149,31 +175,47 @@ runs:
           const baseLength = baseHeader.length + baseFooter.length;
           let output;
 
-          // Check if comment exceeds GitHub's limit and truncate if necessary
+          // Check if comment exceeds GitHub's limit and truncate if necessary. The decision
+          // is made against the note-less budget: the truncation notice only exists when we
+          // truncate, so reserving room for it up front would truncate a plan that fits.
           if (baseLength + plan.length > MAX_COMMENT_LENGTH) {
             const availableForPlan = MAX_COMMENT_LENGTH - baseLength;
-            const truncationNotice = `\n\n... [Plan truncated - showing first ${availableForPlan} characters only. See workflow logs for full output.] ...`;
-            const maxPlanLength = availableForPlan - truncationNotice.length;
+            // Notice length depends on the number it reports, so size it with a placeholder
+            // first, then render it with the real count - otherwise the comment can exceed
+            // the cap when the digit count grows.
+            const notice = (n) => `\n\n... [Plan truncated - showing first ${n} characters only. See workflow logs for full output.] ...`;
+            const maxPlanLength = availableForPlan - notice(availableForPlan).length;
 
             if (maxPlanLength > 0) {
-              const truncatedPlan = plan.substring(0, maxPlanLength) + truncationNotice;
+              const truncatedPlan = plan.substring(0, maxPlanLength) + notice(maxPlanLength);
               output = `${baseHeader}${truncatedPlan}${baseFooter}`;
             } else {
-              output = `#### Environment: ${environment}
+              output = `${sticky ? marker + '\n' : ''}#### Environment: ${environment}
 
-              #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+          #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
 
-              Plan output is too large to display. Please check the workflow logs for the full plan.
+          Plan output is too large to display. Please check the workflow logs for the full plan.
 
-              *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ inputs.working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+          *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ inputs.working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
             }
           } else {
             output = `${baseHeader}${plan}${baseFooter}`;
           }
 
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: output
-          })
+          const issue_number = Number('${{ inputs.pr_number }}') || context.issue.number;
+          const { owner, repo } = context.repo;
+
+          if (sticky) {
+            // Paginate: listComments returns 30 per page by default, so on a busy PR the
+            // marker would be missed and a duplicate sticky comment created.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: output });
+              return;
+            }
+          }
+
+          await github.rest.issues.createComment({ owner, repo, issue_number, body: output });

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -234,7 +234,15 @@ runs:
               throw new Error(`pr_number must be a positive integer, got "${rawPrNumber}"`);
             }
           } else {
+            // Do not rely on the step-level `if:` matching this trim: a whitespace-only
+            // pr_number satisfies `!= ''` there, lands here, and would otherwise reach the
+            // API as an undefined issue number with a confusing error.
             issue_number = context.issue.number;
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              throw new Error(
+                'no pull request to comment on: pass a valid pr_number when running outside a pull_request event',
+              );
+            }
           }
           const { owner, repo } = context.repo;
 

--- a/tests/test-backtick-escaping.js
+++ b/tests/test-backtick-escaping.js
@@ -20,7 +20,6 @@ function buildPlanComment(environment, validationOutput, plan, steps, context) {
   const escapedPlan = plan.replace(/`/g, '\\`');
 
   const baseHeader = `#### Environment: ${environment}
-          #### Terraform Format and Style 🖌\`${steps.fmt.outcome}\`
           #### Terraform Initialization ⚙️\`${steps.init.outcome}\`
           #### Terraform Validation 🤖\`${steps.validate.outcome}\`
           <details><summary>Validation Output</summary>
@@ -53,7 +52,6 @@ function runTests() {
   console.log('Running backtick escaping tests...\n');
 
   const mockSteps = {
-    fmt: { outcome: 'success' },
     init: { outcome: 'success' },
     validate: { outcome: 'success' },
     plan: { outcome: 'success' }

--- a/tests/test-comment-length.js
+++ b/tests/test-comment-length.js
@@ -21,7 +21,6 @@ function buildPlanComment(environment, validationOutput, plan, steps, context) {
   const escapedPlan = plan.replace(/`/g, '\\`');
 
   const baseHeader = `#### Environment: ${environment}
-          #### Terraform Format and Style 🖌\`${steps.fmt.outcome}\`
           #### Terraform Initialization ⚙️\`${steps.init.outcome}\`
           #### Terraform Validation 🤖\`${steps.validate.outcome}\`
           <details><summary>Validation Output</summary>
@@ -52,20 +51,22 @@ function buildPlanComment(environment, validationOutput, plan, steps, context) {
   // Check if comment exceeds GitHub's limit and truncate if necessary
   if (baseLength + escapedPlan.length > MAX_COMMENT_LENGTH) {
     const availableForPlan = MAX_COMMENT_LENGTH - baseLength;
-    const truncationNotice = `\n\n... [Plan truncated - showing first ${availableForPlan} characters only. See workflow logs for full output.] ...`;
-    const maxPlanLength = availableForPlan - truncationNotice.length;
+    // Notice length depends on the number it reports, so size it with a placeholder first,
+    // then render it with the real count.
+    const notice = (n) => `\n\n... [Plan truncated - showing first ${n} characters only. See workflow logs for full output.] ...`;
+    const maxPlanLength = availableForPlan - notice(availableForPlan).length;
 
     if (maxPlanLength > 0) {
-      const truncatedPlan = escapedPlan.substring(0, maxPlanLength) + truncationNotice;
+      const truncatedPlan = escapedPlan.substring(0, maxPlanLength) + notice(maxPlanLength);
       output = `${baseHeader}${truncatedPlan}${baseFooter}`;
     } else {
       output = `#### Environment: ${environment}
 
-              #### Terraform Plan 📖\`${steps.plan.outcome}\`
+#### Terraform Plan 📖\`${steps.plan.outcome}\`
 
-              Plan output is too large to display. Please check the workflow logs for the full plan.
+Plan output is too large to display. Please check the workflow logs for the full plan.
 
-              *Pusher: @${context.actor}, Action: \`${context.event_name}\`, Working Directory: \`${context.working_dir}\`, Workflow: \`${context.workflow}\`*`;
+*Pusher: @${context.actor}, Action: \`${context.event_name}\`, Working Directory: \`${context.working_dir}\`, Workflow: \`${context.workflow}\`*`;
     }
   } else {
     output = `${baseHeader}${escapedPlan}${baseFooter}`;

--- a/tests/test-comment-length.js
+++ b/tests/test-comment-length.js
@@ -20,7 +20,12 @@ function buildPlanComment(environment, validationOutput, plan, steps, context) {
   const escapedValidationOutput = validationOutput.replace(/`/g, '\\`');
   const escapedPlan = plan.replace(/`/g, '\\`');
 
-  const baseHeader = `#### Environment: ${environment}
+  // Sticky mode (the action's default) prefixes a hidden marker line, which counts toward
+  // the comment budget. Model it when the caller supplies one so boundary maths here
+  // matches the action's real sticky output.
+  const markerPrefix = context.marker ? `${context.marker}\n` : '';
+
+  const baseHeader = `${markerPrefix}#### Environment: ${environment}
           #### Terraform Initialization ⚙️\`${steps.init.outcome}\`
           #### Terraform Validation 🤖\`${steps.validate.outcome}\`
           <details><summary>Validation Output</summary>
@@ -60,7 +65,7 @@ function buildPlanComment(environment, validationOutput, plan, steps, context) {
       const truncatedPlan = escapedPlan.substring(0, maxPlanLength) + notice(maxPlanLength);
       output = `${baseHeader}${truncatedPlan}${baseFooter}`;
     } else {
-      output = `#### Environment: ${environment}
+      output = `${markerPrefix}#### Environment: ${environment}
 
 #### Terraform Plan 📖\`${steps.plan.outcome}\`
 
@@ -290,6 +295,32 @@ function runTests() {
     assert.strictEqual(comment.length <= MAX_COMMENT_LENGTH, true, `Should be within limit: ${comment.length} > ${MAX_COMMENT_LENGTH}`);
     assert.strictEqual(comment.includes('truncated'), false, 'Should not truncate when fits');
     console.log(`   Comment length: ${comment.length} chars (limit: ${MAX_COMMENT_LENGTH})`);
+    console.log('✓ PASSED\n');
+    passed++;
+  } catch (error) {
+    console.log(`✗ FAILED: ${error.message}\n`);
+    failed++;
+  }
+
+  // Test 8: Sticky marker counts toward the budget
+  try {
+    console.log('Test 8: Sticky marker counts toward the comment budget');
+    const marker = '<!-- terraform-plan:dev:environments/dev -->';
+    const stickyContext = { ...mockContext, marker };
+    const plan = '+'.repeat(200000);
+
+    const sticky = buildPlanComment('DEV', 'Validation successful', plan, mockSteps, stickyContext);
+    const plain = buildPlanComment('DEV', 'Validation successful', plan, mockSteps, mockContext);
+
+    assert.strictEqual(sticky.startsWith(`${marker}\n`), true, 'Sticky output should lead with the marker');
+    assert.strictEqual(sticky.length <= MAX_COMMENT_LENGTH, true, `Should be within limit: ${sticky.length}`);
+    // The marker consumes budget, so less of the plan survives than without it.
+    assert.strictEqual(
+      sticky.length - plain.length <= marker.length + 1,
+      true,
+      'Marker must be accounted for in the budget, not appended on top of a full-size comment',
+    );
+    console.log(`   Sticky: ${sticky.length} chars, plain: ${plain.length} chars (limit: ${MAX_COMMENT_LENGTH})`);
     console.log('✓ PASSED\n');
     passed++;
   } catch (error) {

--- a/tests/test-comment-length.js
+++ b/tests/test-comment-length.js
@@ -131,7 +131,6 @@ function runTests() {
   console.log('Running comment length validation tests...\n');
 
   const mockSteps = {
-    fmt: { outcome: 'success' },
     init: { outcome: 'success' },
     validate: { outcome: 'success' },
     plan: { outcome: 'success' },
@@ -261,7 +260,6 @@ function runTests() {
   try {
     console.log('Test 7: Plan right at the boundary (no truncation needed)');
     const baseHeader = `#### Environment: DEV
-          #### Terraform Format and Style 🖌\`success\`
           #### Terraform Initialization ⚙️\`success\`
           #### Terraform Validation 🤖\`success\`
           <details><summary>Validation Output</summary>

--- a/tests/test-sticky-comment.js
+++ b/tests/test-sticky-comment.js
@@ -50,8 +50,21 @@ function interpolate(src, { mode, marker, prNumber }) {
     .replace(/\$\{\{ github\.workflow \}\}/g, 'Plan');
 }
 
+/** Read a declared input default straight out of action.yml (no YAML dependency). */
+function declaredInputDefault(name) {
+  const lines = fs.readFileSync(ACTION, 'utf8').split('\n');
+  const start = lines.findIndex((l) => l.trim() === `${name}:`);
+  assert.ok(start !== -1, `input ${name} not declared in action.yml`);
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s{2}\S/.test(line)) break; // next input
+    const m = line.match(/^\s+default:\s*"?([^"]*)"?\s*$/);
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
 async function runAction({
-  mode = 'new',
+  mode = 'sticky',
   marker = '',
   prNumber = '',
   planSize = 100,
@@ -102,7 +115,15 @@ async function test(name, fn) {
 (async () => {
   console.log('Running sticky comment tests...\n');
 
-  await test('default mode posts a new comment and embeds no marker', async () => {
+  await test('comment_mode defaults to sticky', async () => {
+    assert.strictEqual(declaredInputDefault('comment_mode'), 'sticky');
+  });
+
+  await test('comment_marker defaults to empty so the marker is derived', async () => {
+    assert.strictEqual(declaredInputDefault('comment_marker'), '');
+  });
+
+  await test('new mode appends a fresh comment and embeds no marker', async () => {
     const { call, calls } = await runAction({ mode: 'new' });
     assert.strictEqual(call.op, 'create');
     assert.ok(!call.body.includes('terraform-plan:'), 'marker leaked into non-sticky comment');
@@ -152,6 +173,30 @@ async function test(name, fn) {
     const { call } = await runAction({ mode: 'new', prNumber: '399', contextIssue: undefined });
     assert.strictEqual(call.op, 'create');
     assert.strictEqual(call.issue, 399);
+  });
+
+  await test('a comment merely quoting the marker is not treated as the sticky comment', async () => {
+    const { call } = await runAction({
+      mode: 'sticky',
+      // The plan text is embedded verbatim, so a marker can legitimately appear mid-body.
+      existingComments: [{ id: 88, body: `someone quoted this:\n${DEFAULT_MARKER}\nin their reply` }],
+    });
+    assert.strictEqual(call.op, 'create', 'must not hijack a comment that only mentions the marker');
+  });
+
+  await test('a malformed pr_number fails loudly instead of retargeting the event PR', async () => {
+    for (const bad of ['abc', '0', '-3', '1.5']) {
+      await assert.rejects(
+        () => runAction({ mode: 'new', prNumber: bad, contextIssue: 5 }),
+        /pr_number must be a positive integer/,
+        `pr_number "${bad}" should have been rejected`,
+      );
+    }
+  });
+
+  await test('an empty pr_number falls back to the event PR', async () => {
+    const { call } = await runAction({ mode: 'new', prNumber: '   ', contextIssue: 12 });
+    assert.strictEqual(call.issue, 12);
   });
 
   await test('sticky comment stays within the GitHub comment limit', async () => {

--- a/tests/test-sticky-comment.js
+++ b/tests/test-sticky-comment.js
@@ -218,6 +218,17 @@ async function test(name, fn) {
     assert.strictEqual(call.issue, 12);
   });
 
+  await test('whitespace-only pr_number off a PR event fails clearly, not at the API', async () => {
+    // The step-level `if:` treats "   " as non-empty and lets the step run, but the script
+    // trims it away - without a guard this reaches the API as an undefined issue number.
+    // null, not undefined: a default parameter would swallow undefined and hand the script
+    // a valid PR number, making this assertion vacuous.
+    await assert.rejects(
+      () => runAction({ mode: 'new', prNumber: '   ', contextIssue: null }),
+      /no pull request to comment on/,
+    );
+  });
+
   await test('sticky comment stays within the GitHub comment limit', async () => {
     for (const planSize of [60000, 65000, 100000, 500000]) {
       const { call } = await runAction({ mode: 'sticky', planSize });

--- a/tests/test-sticky-comment.js
+++ b/tests/test-sticky-comment.js
@@ -36,18 +36,35 @@ function extractCommentScript() {
   return body.join('\n');
 }
 
-/** Substitute the ${{ }} expressions the runner would have already interpolated. */
-function interpolate(src, { mode, marker, prNumber }) {
-  return src
-    .replace(/\$\{\{ inputs\.comment_mode \}\}/g, mode)
-    .replace(/\$\{\{ inputs\.comment_marker \}\}/g, marker)
-    .replace(/\$\{\{ inputs\.environment \}\}/g, 'staging')
-    .replace(/\$\{\{ inputs\.working_dir \}\}/g, 'live/workloads')
-    .replace(/\$\{\{ inputs\.pr_number \}\}/g, prNumber)
-    .replace(/\$\{\{ steps\.\w+\.outcome \}\}/g, 'success')
-    .replace(/\$\{\{ github\.actor \}\}/g, 'tester')
-    .replace(/\$\{\{ github\.event_name \}\}/g, 'pull_request')
-    .replace(/\$\{\{ github\.workflow \}\}/g, 'Plan');
+/**
+ * The action passes every consumer-controlled value through the step's env rather than
+ * interpolating it into the script, so the script must contain no ${{ }} expressions -
+ * interpolating them would be a script-injection vector. Assert that here: if someone
+ * reintroduces one, these tests would silently stop matching the real behaviour.
+ */
+function assertNoInterpolation(src) {
+  const found = src.split('\n').filter((l) => l.includes('${{'));
+  assert.strictEqual(
+    found.length, 0,
+    `script must not interpolate expressions (script-injection risk):\n${found.join('\n')}`,
+  );
+}
+
+/** Set the env the action declares on the step. */
+function applyEnv({ mode, marker, prNumber }) {
+  Object.assign(process.env, {
+    PLAN_ENVIRONMENT: 'staging',
+    PLAN_WORKING_DIR: 'live/workloads',
+    PLAN_COMMENT_MODE: mode,
+    PLAN_COMMENT_MARKER: marker,
+    PLAN_PR_NUMBER: prNumber,
+    PLAN_INIT_OUTCOME: 'success',
+    PLAN_VALIDATE_OUTCOME: 'success',
+    PLAN_PLAN_OUTCOME: 'success',
+    PLAN_ACTOR: 'tester',
+    PLAN_EVENT_NAME: 'pull_request',
+    PLAN_WORKFLOW: 'Plan',
+  });
 }
 
 /** Read a declared input default straight out of action.yml (no YAML dependency). */
@@ -91,7 +108,9 @@ async function runAction({
   };
   const context = { repo: { owner: 'o', repo: 'r' }, issue: { number: contextIssue } };
 
-  const src = interpolate(extractCommentScript(), { mode, marker, prNumber });
+  const src = extractCommentScript();
+  assertNoInterpolation(src);
+  applyEnv({ mode, marker, prNumber });
   await new Function('github', 'context', 'require', `return (async () => {${src}})()`)(github, context, require);
 
   return { call: calls[0], calls, paginateOpts };

--- a/tests/test-sticky-comment.js
+++ b/tests/test-sticky-comment.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+/**
+ * Unit test for sticky PR-comment behaviour (terraform-plan)
+ *
+ * Unlike the other suites, this one extracts and executes the real script from
+ * actions/terraform-plan/action.yml rather than mirroring it, so the test cannot
+ * silently drift from the action.
+ *
+ * Usage: node tests/test-sticky-comment.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const MAX_COMMENT_LENGTH = 65536;
+const ACTION = path.join(__dirname, '..', 'actions', 'terraform-plan', 'action.yml');
+
+/**
+ * Pull the github-script body out of the action without a YAML dependency: find the
+ * comment step's `script: |` block and strip its common indentation, which is what the
+ * YAML block scalar does at runtime.
+ */
+function extractCommentScript() {
+  const lines = fs.readFileSync(ACTION, 'utf8').split('\n');
+  const start = lines.findIndex((l) => l.includes('script: |'));
+  assert.ok(start !== -1, 'could not find the script block in action.yml');
+
+  const body = [];
+  const indent = lines[start].search(/\S/) + 2;
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() !== '' && line.search(/\S/) < indent) break;
+    body.push(line.slice(indent));
+  }
+  return body.join('\n');
+}
+
+/** Substitute the ${{ }} expressions the runner would have already interpolated. */
+function interpolate(src, { mode, marker, prNumber }) {
+  return src
+    .replace(/\$\{\{ inputs\.comment_mode \}\}/g, mode)
+    .replace(/\$\{\{ inputs\.comment_marker \}\}/g, marker)
+    .replace(/\$\{\{ inputs\.environment \}\}/g, 'staging')
+    .replace(/\$\{\{ inputs\.working_dir \}\}/g, 'live/workloads')
+    .replace(/\$\{\{ inputs\.pr_number \}\}/g, prNumber)
+    .replace(/\$\{\{ steps\.\w+\.outcome \}\}/g, 'success')
+    .replace(/\$\{\{ github\.actor \}\}/g, 'tester')
+    .replace(/\$\{\{ github\.event_name \}\}/g, 'pull_request')
+    .replace(/\$\{\{ github\.workflow \}\}/g, 'Plan');
+}
+
+async function runAction({
+  mode = 'new',
+  marker = '',
+  prNumber = '',
+  planSize = 100,
+  existingComments = [],
+  contextIssue = 5,
+}) {
+  fs.writeFileSync('/tmp/validate_output.txt', 'Success! The configuration is valid.');
+  fs.writeFileSync('/tmp/plan.out', 'P'.repeat(planSize));
+
+  const calls = [];
+  let paginateOpts = null;
+  const github = {
+    paginate: async (_fn, opts) => {
+      paginateOpts = opts;
+      return existingComments;
+    },
+    rest: {
+      issues: {
+        listComments: 'listComments',
+        updateComment: async (o) => calls.push({ op: 'update', id: o.comment_id, body: o.body }),
+        createComment: async (o) => calls.push({ op: 'create', issue: o.issue_number, body: o.body }),
+      },
+    },
+  };
+  const context = { repo: { owner: 'o', repo: 'r' }, issue: { number: contextIssue } };
+
+  const src = interpolate(extractCommentScript(), { mode, marker, prNumber });
+  await new Function('github', 'context', 'require', `return (async () => {${src}})()`)(github, context, require);
+
+  return { call: calls[0], calls, paginateOpts };
+}
+
+const DEFAULT_MARKER = '<!-- terraform-plan:staging:live/workloads -->';
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`✓ PASSED  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`✗ FAILED  ${name}\n   ${err.message}`);
+    failed++;
+  }
+}
+
+(async () => {
+  console.log('Running sticky comment tests...\n');
+
+  await test('default mode posts a new comment and embeds no marker', async () => {
+    const { call, calls } = await runAction({ mode: 'new' });
+    assert.strictEqual(call.op, 'create');
+    assert.ok(!call.body.includes('terraform-plan:'), 'marker leaked into non-sticky comment');
+    assert.strictEqual(calls.length, 1);
+  });
+
+  await test('sticky with no existing comment creates one carrying the marker', async () => {
+    const { call } = await runAction({ mode: 'sticky' });
+    assert.strictEqual(call.op, 'create');
+    assert.ok(call.body.startsWith(DEFAULT_MARKER), 'sticky comment must lead with its marker');
+  });
+
+  await test('sticky updates the existing comment in place', async () => {
+    const { call } = await runAction({
+      mode: 'sticky',
+      existingComments: [{ id: 7, body: 'unrelated' }, { id: 42, body: `${DEFAULT_MARKER}\nold plan` }],
+    });
+    assert.strictEqual(call.op, 'update');
+    assert.strictEqual(call.id, 42);
+  });
+
+  await test('sticky requests all comment pages (marker must not be missed)', async () => {
+    const { paginateOpts } = await runAction({ mode: 'sticky' });
+    assert.strictEqual(paginateOpts.per_page, 100, 'must page at 100 to avoid duplicate stickies');
+  });
+
+  await test('a custom marker is honoured', async () => {
+    const custom = '<!-- tf-plan:staging -->';
+    const { call } = await runAction({
+      mode: 'sticky',
+      marker: custom,
+      existingComments: [{ id: 99, body: `${custom}\nold` }],
+    });
+    assert.strictEqual(call.op, 'update');
+    assert.strictEqual(call.id, 99);
+  });
+
+  await test('different markers do not collide on the same PR', async () => {
+    const { call } = await runAction({
+      mode: 'sticky',
+      existingComments: [{ id: 11, body: '<!-- terraform-plan:dev:live/workloads -->\ndev plan' }],
+    });
+    assert.strictEqual(call.op, 'create', 'staging must not overwrite the dev sticky comment');
+  });
+
+  await test('pr_number overrides the event PR', async () => {
+    const { call } = await runAction({ mode: 'new', prNumber: '399', contextIssue: undefined });
+    assert.strictEqual(call.op, 'create');
+    assert.strictEqual(call.issue, 399);
+  });
+
+  await test('sticky comment stays within the GitHub comment limit', async () => {
+    for (const planSize of [60000, 65000, 100000, 500000]) {
+      const { call } = await runAction({ mode: 'sticky', planSize });
+      assert.ok(
+        call.body.length <= MAX_COMMENT_LENGTH,
+        `plan ${planSize} produced ${call.body.length} chars (limit ${MAX_COMMENT_LENGTH})`,
+      );
+    }
+  });
+
+  await test('a plan that fits is not truncated just to reserve room for the notice', async () => {
+    const { call } = await runAction({ mode: 'sticky', planSize: 100 });
+    assert.ok(!call.body.includes('Plan truncated'), 'small plan should not be truncated');
+  });
+
+  console.log('\n' + '='.repeat(50));
+  console.log(`Tests completed: ${passed + failed}`);
+  console.log(`Passed: ${passed}`);
+  console.log(`Failed: ${failed}`);
+  console.log('='.repeat(50));
+
+  if (failed > 0) process.exit(1);
+})();

--- a/tests/test-sticky-comment.js
+++ b/tests/test-sticky-comment.js
@@ -51,10 +51,10 @@ function assertNoInterpolation(src) {
 }
 
 /** Set the env the action declares on the step. */
-function applyEnv({ mode, marker, prNumber }) {
+function applyEnv({ mode, marker, prNumber, workingDir }) {
   Object.assign(process.env, {
     PLAN_ENVIRONMENT: 'staging',
-    PLAN_WORKING_DIR: 'live/workloads',
+    PLAN_WORKING_DIR: workingDir,
     PLAN_COMMENT_MODE: mode,
     PLAN_COMMENT_MARKER: marker,
     PLAN_PR_NUMBER: prNumber,
@@ -84,6 +84,7 @@ async function runAction({
   mode = 'sticky',
   marker = '',
   prNumber = '',
+  workingDir = 'live/workloads',
   planSize = 100,
   existingComments = [],
   contextIssue = 5,
@@ -110,7 +111,7 @@ async function runAction({
 
   const src = extractCommentScript();
   assertNoInterpolation(src);
-  applyEnv({ mode, marker, prNumber });
+  applyEnv({ mode, marker, prNumber, workingDir });
   await new Function('github', 'context', 'require', `return (async () => {${src}})()`)(github, context, require);
 
   return { call: calls[0], calls, paginateOpts };
@@ -216,6 +217,25 @@ async function test(name, fn) {
   await test('an empty pr_number falls back to the event PR', async () => {
     const { call } = await runAction({ mode: 'new', prNumber: '   ', contextIssue: 12 });
     assert.strictEqual(call.issue, 12);
+  });
+
+  await test('a multi-line comment_marker fails fast instead of never matching', async () => {
+    // Matching compares the comment's first line, so a multi-line marker could never match
+    // and would silently post a new comment every run.
+    for (const bad of ['<!-- a\nb -->', '<!-- a\r\nb -->']) {
+      await assert.rejects(
+        () => runAction({ mode: 'sticky', marker: bad }),
+        /comment_marker must be a single line/,
+      );
+    }
+  });
+
+  await test('backticks in working_dir cannot break out of the inline code span', async () => {
+    const { call } = await runAction({ mode: 'sticky', workingDir: 'live/`rm -rf`/workloads' });
+    assert.ok(
+      call.body.includes('Working Directory: `live/\\`rm -rf\\`/workloads`'),
+      `backtick was not escaped in the footer:\n${call.body.slice(-200)}`,
+    );
   });
 
   await test('whitespace-only pr_number off a PR event fails clearly, not at the API', async () => {


### PR DESCRIPTION
> [!WARNING]
> **Breaking change.** Plan comments are now **sticky by default**. Consumers relying on a new comment per run must set `comment_mode: new`. Everyone on the default will see one comment per environment updated in place instead of an accumulating thread.

## Problem

Every plan run adds a **new** PR comment. On a PR that runs several plans - multiple environments, or multiple Terraform roots - that becomes a new comment per plan per push, and the actual review discussion gets buried.

## Change

Add `comment_mode: sticky`, which updates a single comment in place instead of appending.

- The sticky comment is identified by a hidden HTML marker in its body.
- `comment_marker` defaults to `<!-- terraform-plan:<environment>:<working_dir> -->`, so concurrent plans on the same PR keep their own comments rather than overwriting each other. Override it to group differently.
- The comment listing is paginated at 100. The default 30-per-page listing misses the marker on a busy PR and silently creates a duplicate sticky comment.

**`comment_mode` defaults to `sticky`** - see the breaking-change note above. Set `comment_mode: new` to keep appending a fresh comment each run.

## Also fixed in the same step

While in the comment builder, three existing defects:

| Issue | Detail |
|---|---|
| Empty "Format and Style" line | The comment rendered `#### Terraform Format and Style` from `steps.fmt.outcome`, but this action has no `fmt` step (the ids are `init` / `validate` / `plan`), so it always came out blank. Line removed. |
| Truncation notice overstated | It reported `availableForPlan` - the budget *before* subtracting the notice - rather than the number of characters actually shown. |
| Fallback rendered as a code block | The "plan output is too large" branch was indented inside the template literal, so markdown rendered the whole fallback as an indented code block. |

Also adds `pr_number`, so a `workflow_dispatch`-driven plan can comment on a PR; previously commenting required a `pull_request` event.

## Tests

`tests/test-sticky-comment.js` **extracts and executes the real script from `action.yml`** rather than mirroring it, so it cannot drift from the action the way a copied implementation can. 9 cases: default-mode has no marker, sticky creates then updates in place, custom marker honoured, distinct markers don't collide, pagination is requested at 100, `pr_number` override, comment stays within the 65536 cap across plan sizes up to 500k, and a plan that fits is not truncated merely to reserve room for the notice.

Verified the suite actually catches regressions by mutation: reverting pagination to 30 fails the pagination case, and swapping `updateComment` for `createComment` fails the update-in-place and custom-marker cases.

`tests/test-comment-length.js` mirrors the action's logic in a copy (as noted in its own header comment), so it was updated to match - otherwise it would have kept asserting against the removed `fmt` line and the old notice.

Existing suites (`test-comment-length`, `test-backtick-escaping`, `test-refresh-configuration`) all pass, and the new suite is wired into `pr-check.yml`.



## Review feedback addressed

- **Marker matching hardened.** Detection used `includes(marker)`, which could latch onto an unrelated comment that merely quotes the marker - the plan text is embedded verbatim, so a marker can legitimately appear mid-body. Now matches the marker as the comment's **first line**.
- **`pr_number` validated.** It was parsed as `Number(x) || context.issue.number`, so a non-numeric value (or `0`) silently fell back to the event's PR - posting the plan onto the wrong pull request. It now fails loudly on anything that is not a positive integer, and only falls back when genuinely empty.

Both are covered by new cases in `tests/test-sticky-comment.js` (14 cases total), including that a comment merely quoting the marker is not hijacked, and that `abc` / `0` / `-3` / `1.5` are all rejected.
