### PR TITLE
fix(terraform-plan): gate on the plan's own exit code, not the wrapper's

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Shellcheck action scripts
+        run: shellcheck actions/*/scripts/*.sh
+
       - name: Run Tests
         run: |
           node tests/test-comment-length.js

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,3 +22,4 @@ jobs:
           node tests/test-backtick-escaping.js
           node tests/test-refresh-configuration.js
           node tests/test-sticky-comment.js
+          node tests/test-plan-gate.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v3.0.1] - 2026-07-25
+
+### Fixed
+
+- `terraform-plan`: the "Check for Plan Failure" gate could miss a failed plan. It read `steps.plan.outputs.exitcode`, which the `setup-terraform` wrapper populates from the last terraform command in the step (the `terraform show`), not the plan - so a plan that errored but was followed by a successful `show` would report success. The plan step now captures its own exit code explicitly (`plan_exitcode`) and the gate keys off that; failure output is preserved so it still appears in the PR comment.
+
 ## [v3.0.0] - 2026-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- `terraform-plan`: the "Check for Plan Failure" gate could miss a failed plan. It read `steps.plan.outputs.exitcode`, which the `setup-terraform` wrapper populates from the last terraform command in the step (the `terraform show`), not the plan - so a plan that errored but was followed by a successful `show` would report success. The plan step now captures its own exit code explicitly (`plan_exitcode`) and the gate keys off that; failure output is preserved so it still appears in the PR comment.
+- `terraform-plan`: the "Check for Plan Failure" gate could miss a failed plan. It read `steps.plan.outputs.exitcode`, which the `setup-terraform` wrapper populates from the last terraform command in the step (the `terraform show`), not the plan - so a plan that errored but was followed by a successful `show` would report success. The plan now runs in `scripts/plan.sh`, which exits non-zero on any failure, and the gate keys off the step outcome. Failure output is preserved so it still appears in the PR comment.
+- `terraform-plan`: the plan comment no longer runs (and crashes on a missing plan file) after a *pre-plan* failure such as an init/creds/decrypt error - it is skipped unless the plan step actually ran.
+
+### Changed
+
+- `terraform-plan`: the inline plan shell and PR-comment JavaScript are extracted to `actions/terraform-plan/scripts/{plan.sh,post-comment.js}` (invoked via `$GITHUB_ACTION_PATH`), so they are shellcheck'd / unit-tested directly instead of being embedded in `action.yml`. Behavior is unchanged.
 
 ## [v3.0.0] - 2026-07-25
 

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -109,51 +109,30 @@ runs:
     - name: Terraform Plan
       id: plan
       shell: bash
-      run: |
-        # Capture the plan's OWN exit code and gate on it. Relying on
-        # steps.plan.outputs.exitcode is unsafe: the setup-terraform wrapper sets that from
-        # the LAST terraform command in the step (the `show` below), not the plan, so a
-        # failed plan could go unreported. Record the plan code explicitly instead.
-        # Clean the fixed-path temp files via a trap so they never leak, even when `set -e`
-        # aborts the step early (e.g. a failing `show`) before a trailing rm would run. Only
-        # plan.out is kept, for the comment step.
-        trap 'rm -f /tmp/plan.tmp /tmp/plan.raw' EXIT
-        set +e
-        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out=/tmp/plan.tmp 2>&1 | tee /tmp/plan.raw
-        code=${PIPESTATUS[0]}
-        set -e
-        echo "plan_exitcode=${code}" >> "${GITHUB_OUTPUT}"
-        if [ "${code}" -eq 0 ]; then
-          # 2>&1 so a `show` failure (which writes to stderr) still lands in plan.out and
-          # thus in the PR comment, rather than leaving it empty.
-          terraform show -no-color /tmp/plan.tmp > /tmp/plan.out 2>&1
-        else
-          # Preserve the failure output so it still surfaces in the PR comment.
-          cp /tmp/plan.raw /tmp/plan.out
-        fi
-      continue-on-error: true
       working-directory: ${{ inputs.working_dir }}
+      continue-on-error: true
+      env:
+        REFRESH: ${{ inputs.refresh }}
+      run: bash "${GITHUB_ACTION_PATH}/scripts/plan.sh"
 
-    # Fail on a plan error (plan_exitcode) OR any other failure inside the plan step, e.g. a
-    # `terraform show` that fails after a successful plan - continue-on-error keeps the job
-    # alive to here, so outcome == 'failure' is how those non-plan failures surface.
+    # plan.sh exits non-zero on any failure (plan error, or a failing show), so the step
+    # outcome is the single reliable signal - see actions/terraform-plan/scripts/plan.sh.
     - name: Check for Plan Failure
-      if: steps.plan.outputs.plan_exitcode != '0' || steps.plan.outcome == 'failure'
+      if: steps.plan.outcome == 'failure'
       shell: bash
       run: |
-        echo "::error:: Terraform plan failed (exit ${{ steps.plan.outputs.plan_exitcode }}, outcome ${{ steps.plan.outcome }})"
+        echo "::error:: Terraform plan failed (exit ${{ steps.plan.outputs.plan_exitcode }})"
         exit 1
 
-    # always(): the failure gate above exits 1 on a plan/show error, so without always()
-    # this step would be skipped and the preserved failure output would never post. Running
-    # it regardless lets a failed plan still surface its error in the PR comment.
+    # Comment when the plan actually ran (success or failure) - not after a pre-plan failure
+    # that skips it, which would leave post-comment.js nothing to read. Runs even though the
+    # gate above exited 1, so a failed plan still surfaces its error in the PR.
     - name: Post Terraform Plan Results to PR
       uses: actions/github-script@v8
-      if: ${{ always() && (github.event_name == 'pull_request' || inputs.pr_number != '') }}
+      if: ${{ !cancelled() && steps.plan.outcome != 'skipped' && (github.event_name == 'pull_request' || inputs.pr_number != '') }}
       env:
-        # Passed as environment variables rather than interpolated into the script body: a
-        # value containing a quote would otherwise produce invalid JavaScript, and inputs
-        # are consumer-controlled, so interpolating them is a script-injection vector.
+        # Passed via env, never interpolated into the script body: consumer-controlled inputs
+        # in a github-script body are a script-injection vector.
         PLAN_ENVIRONMENT: ${{ inputs.environment }}
         PLAN_WORKING_DIR: ${{ inputs.working_dir }}
         PLAN_COMMENT_MODE: ${{ inputs.comment_mode }}
@@ -168,131 +147,4 @@ runs:
       with:
         github-token: ${{ inputs.github_token }}
         script: |
-          const fs = require('fs')
-
-          const validationOutput = fs.readFileSync('/tmp/validate_output.txt', 'utf8').replace(/`/g, '\\`')
-          fs.unlinkSync('/tmp/validate_output.txt')
-
-          let plan = fs.readFileSync('/tmp/plan.out', 'utf8').replace(/`/g, '\\`')
-          fs.unlinkSync('/tmp/plan.out')
-
-          const environment = process.env.PLAN_ENVIRONMENT.toUpperCase()
-          const workingDir = process.env.PLAN_WORKING_DIR
-          const initOutcome = process.env.PLAN_INIT_OUTCOME
-          const validateOutcome = process.env.PLAN_VALIDATE_OUTCOME
-          const planOutcome = process.env.PLAN_PLAN_OUTCOME
-
-          const sticky = process.env.PLAN_COMMENT_MODE === 'sticky';
-          // Trimmed so an accidentally padded marker still matches. The default keeps
-          // concurrent plans on one PR in separate comments (a PR that plans several
-          // environments or roots would otherwise fight over a single comment).
-          const marker = (process.env.PLAN_COMMENT_MARKER || '').trim() ||
-            `<!-- terraform-plan:${process.env.PLAN_ENVIRONMENT}:${workingDir} -->`;
-          // The sticky comment is matched on its first line, so a multi-line marker could
-          // never match and would silently post a new comment on every run.
-          if (sticky && /[\r\n]/.test(marker)) {
-            throw new Error('comment_marker must be a single line');
-          }
-
-          // These render inside inline-code spans; an embedded backtick would break out of
-          // the span and mangle the comment, so escape them like the plan output.
-          const inline = (v) => String(v ?? '').replace(/`/g, '\\`');
-
-          // GitHub comment body limit is 65536 characters
-          const MAX_COMMENT_LENGTH = 65536
-
-          // Calculate the base template size (without the plan content)
-          const baseHeader = `${sticky ? marker + '\n' : ''}#### Environment: ${environment}
-          #### Terraform Initialization ⚙️\`${initOutcome}\`
-          #### Terraform Validation 🤖\`${validateOutcome}\`
-          <details><summary>Validation Output</summary>
-
-          \`\`\`\n
-          ${validationOutput}
-          \`\`\`
-
-          </details>
-
-          #### Terraform Plan 📖\`${planOutcome}\`
-
-          <details><summary>Show Plan</summary>
-
-          \`\`\`\n
-          `;
-
-          const baseFooter = `
-          \`\`\`
-
-          </details>
-
-          *Pusher: @${process.env.PLAN_ACTOR}, Action: \`${inline(process.env.PLAN_EVENT_NAME)}\`, Working Directory: \`${inline(workingDir)}\`, Workflow: \`${inline(process.env.PLAN_WORKFLOW)}\`*`;
-
-          const baseLength = baseHeader.length + baseFooter.length;
-          let output;
-
-          // Check if comment exceeds GitHub's limit and truncate if necessary. The decision
-          // is made against the note-less budget: the truncation notice only exists when we
-          // truncate, so reserving room for it up front would truncate a plan that fits.
-          if (baseLength + plan.length > MAX_COMMENT_LENGTH) {
-            const availableForPlan = MAX_COMMENT_LENGTH - baseLength;
-            // Notice length depends on the number it reports, so size it with a placeholder
-            // first, then render it with the real count - otherwise the comment can exceed
-            // the cap when the digit count grows.
-            const notice = (n) => `\n\n... [Plan truncated - showing first ${n} characters only. See workflow logs for full output.] ...`;
-            const maxPlanLength = availableForPlan - notice(availableForPlan).length;
-
-            if (maxPlanLength > 0) {
-              const truncatedPlan = plan.substring(0, maxPlanLength) + notice(maxPlanLength);
-              output = `${baseHeader}${truncatedPlan}${baseFooter}`;
-            } else {
-              output = `${sticky ? marker + '\n' : ''}#### Environment: ${environment}
-
-          #### Terraform Plan 📖\`${planOutcome}\`
-
-          Plan output is too large to display. Please check the workflow logs for the full plan.
-
-          *Pusher: @${process.env.PLAN_ACTOR}, Action: \`${inline(process.env.PLAN_EVENT_NAME)}\`, Working Directory: \`${inline(workingDir)}\`, Workflow: \`${inline(process.env.PLAN_WORKFLOW)}\`*`;
-            }
-          } else {
-            output = `${baseHeader}${plan}${baseFooter}`;
-          }
-
-          // Fail loudly on a malformed pr_number rather than silently falling back to the
-          // event's PR, which would post the plan onto the wrong pull request.
-          const rawPrNumber = (process.env.PLAN_PR_NUMBER || '').trim();
-          let issue_number;
-          if (rawPrNumber !== '') {
-            issue_number = Number(rawPrNumber);
-            if (!Number.isInteger(issue_number) || issue_number <= 0) {
-              throw new Error(`pr_number must be a positive integer, got "${rawPrNumber}"`);
-            }
-          } else {
-            // Do not rely on the step-level `if:` matching this trim: a whitespace-only
-            // pr_number satisfies `!= ''` there, lands here, and would otherwise reach the
-            // API as an undefined issue number with a confusing error.
-            issue_number = context.issue.number;
-            if (!Number.isInteger(issue_number) || issue_number <= 0) {
-              throw new Error(
-                'no pull request to comment on: pass a valid pr_number when running outside a pull_request event',
-              );
-            }
-          }
-          const { owner, repo } = context.repo;
-
-          if (sticky) {
-            // Paginate: listComments returns 30 per page by default, so on a busy PR the
-            // marker would be missed and a duplicate sticky comment created.
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number, per_page: 100,
-            });
-            // Match the marker as the comment's first line, not anywhere in the body: the
-            // plan text is embedded verbatim, so a substring match could latch onto an
-            // unrelated comment that merely quotes the marker.
-            const existing = comments.find((c) => c.body && c.body.split('\n')[0].trim() === marker);
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: output });
-              return;
-            }
-          }
-
-          await github.rest.issues.createComment({ owner, repo, issue_number, body: output });
+          await require(`${process.env.GITHUB_ACTION_PATH}/scripts/post-comment.js`)({ github, context });

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -114,6 +114,10 @@ runs:
         # steps.plan.outputs.exitcode is unsafe: the setup-terraform wrapper sets that from
         # the LAST terraform command in the step (the `show` below), not the plan, so a
         # failed plan could go unreported. Record the plan code explicitly instead.
+        # Clean the fixed-path temp files via a trap so they never leak, even when `set -e`
+        # aborts the step early (e.g. a failing `show`) before a trailing rm would run. Only
+        # plan.out is kept, for the comment step.
+        trap 'rm -f /tmp/plan.tmp /tmp/plan.raw' EXIT
         set +e
         terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out=/tmp/plan.tmp 2>&1 | tee /tmp/plan.raw
         code=${PIPESTATUS[0]}
@@ -125,11 +129,6 @@ runs:
           # Preserve the failure output so it still surfaces in the PR comment.
           cp /tmp/plan.raw /tmp/plan.out
         fi
-        # Clean both fixed-path temp files in every path (a stale plan.tmp/plan.raw could
-        # otherwise leak across invocations on a self-hosted runner). plan.out is kept for
-        # the comment step. Under set -e a failing `show` above aborts here first; that
-        # failure is caught by the outcome check on the gate below.
-        rm -f /tmp/plan.tmp /tmp/plan.raw
       continue-on-error: true
       working-directory: ${{ inputs.working_dir }}
 

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -124,7 +124,9 @@ runs:
         set -e
         echo "plan_exitcode=${code}" >> "${GITHUB_OUTPUT}"
         if [ "${code}" -eq 0 ]; then
-          terraform show -no-color /tmp/plan.tmp > /tmp/plan.out
+          # 2>&1 so a `show` failure (which writes to stderr) still lands in plan.out and
+          # thus in the PR comment, rather than leaving it empty.
+          terraform show -no-color /tmp/plan.tmp > /tmp/plan.out 2>&1
         else
           # Preserve the failure output so it still surfaces in the PR comment.
           cp /tmp/plan.raw /tmp/plan.out

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -110,17 +110,30 @@ runs:
       id: plan
       shell: bash
       run: |
-        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out=/tmp/plan.tmp
-        terraform show -no-color /tmp/plan.tmp > /tmp/plan.out
-        rm -f /tmp/plan.tmp
+        # Capture the plan's OWN exit code and gate on it. Relying on
+        # steps.plan.outputs.exitcode is unsafe: the setup-terraform wrapper sets that from
+        # the LAST terraform command in the step (the `show` below), not the plan, so a
+        # failed plan could go unreported. Record the plan code explicitly instead.
+        set +e
+        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out=/tmp/plan.tmp 2>&1 | tee /tmp/plan.raw
+        code=${PIPESTATUS[0]}
+        set -e
+        echo "plan_exitcode=${code}" >> "${GITHUB_OUTPUT}"
+        if [ "${code}" -eq 0 ]; then
+          terraform show -no-color /tmp/plan.tmp > /tmp/plan.out
+          rm -f /tmp/plan.tmp
+        else
+          # Preserve the failure output so it still surfaces in the PR comment.
+          cp /tmp/plan.raw /tmp/plan.out
+        fi
       continue-on-error: true
       working-directory: ${{ inputs.working_dir }}
 
     - name: Check for Plan Failure
-      if: steps.plan.outputs.exitcode == 1
+      if: steps.plan.outputs.plan_exitcode != '0'
       shell: bash
       run: |
-        echo "::error:: Terraform plan failed"
+        echo "::error:: Terraform plan failed (exit ${{ steps.plan.outputs.plan_exitcode }})"
         exit 1
 
     - name: Post Terraform Plan Results to PR

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -142,9 +142,12 @@ runs:
         echo "::error:: Terraform plan failed (exit ${{ steps.plan.outputs.plan_exitcode }}, outcome ${{ steps.plan.outcome }})"
         exit 1
 
+    # always(): the failure gate above exits 1 on a plan/show error, so without always()
+    # this step would be skipped and the preserved failure output would never post. Running
+    # it regardless lets a failed plan still surface its error in the PR comment.
     - name: Post Terraform Plan Results to PR
       uses: actions/github-script@v8
-      if: ${{ github.event_name == 'pull_request' || inputs.pr_number != '' }}
+      if: ${{ always() && (github.event_name == 'pull_request' || inputs.pr_number != '') }}
       env:
         # Passed as environment variables rather than interpolated into the script body: a
         # value containing a quote would otherwise produce invalid JavaScript, and inputs

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -121,7 +121,7 @@ runs:
       if: steps.plan.outcome == 'failure'
       shell: bash
       run: |
-        echo "::error:: Terraform plan failed (exit ${{ steps.plan.outputs.plan_exitcode }})"
+        echo "::error:: Terraform plan step failed - see the plan output in the PR comment and the logs (plan_exitcode=${{ steps.plan.outputs.plan_exitcode }}; 0 means a post-plan error such as terraform show)"
         exit 1
 
     # Comment when the plan actually ran (success or failure) - not after a pre-plan failure

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -121,19 +121,26 @@ runs:
         echo "plan_exitcode=${code}" >> "${GITHUB_OUTPUT}"
         if [ "${code}" -eq 0 ]; then
           terraform show -no-color /tmp/plan.tmp > /tmp/plan.out
-          rm -f /tmp/plan.tmp
         else
           # Preserve the failure output so it still surfaces in the PR comment.
           cp /tmp/plan.raw /tmp/plan.out
         fi
+        # Clean both fixed-path temp files in every path (a stale plan.tmp/plan.raw could
+        # otherwise leak across invocations on a self-hosted runner). plan.out is kept for
+        # the comment step. Under set -e a failing `show` above aborts here first; that
+        # failure is caught by the outcome check on the gate below.
+        rm -f /tmp/plan.tmp /tmp/plan.raw
       continue-on-error: true
       working-directory: ${{ inputs.working_dir }}
 
+    # Fail on a plan error (plan_exitcode) OR any other failure inside the plan step, e.g. a
+    # `terraform show` that fails after a successful plan - continue-on-error keeps the job
+    # alive to here, so outcome == 'failure' is how those non-plan failures surface.
     - name: Check for Plan Failure
-      if: steps.plan.outputs.plan_exitcode != '0'
+      if: steps.plan.outputs.plan_exitcode != '0' || steps.plan.outcome == 'failure'
       shell: bash
       run: |
-        echo "::error:: Terraform plan failed (exit ${{ steps.plan.outputs.plan_exitcode }})"
+        echo "::error:: Terraform plan failed (exit ${{ steps.plan.outputs.plan_exitcode }}, outcome ${{ steps.plan.outcome }})"
         exit 1
 
     - name: Post Terraform Plan Results to PR

--- a/actions/terraform-plan/scripts/plan.sh
+++ b/actions/terraform-plan/scripts/plan.sh
@@ -11,8 +11,12 @@ set -euo pipefail
 
 trap 'rm -f /tmp/plan.tmp /tmp/plan.raw /tmp/plan.err' EXIT
 
-plan_code=0
-terraform plan -input=false -no-color -lock=false -refresh="${REFRESH}" -out=/tmp/plan.tmp 2>&1 | tee /tmp/plan.raw || plan_code=$?
+# Capture terraform's OWN exit code via PIPESTATUS[0] - not the pipeline status, which under
+# pipefail could be tee's. set +e so a plan error doesn't abort before we read it.
+set +e
+terraform plan -input=false -no-color -lock=false -refresh="${REFRESH}" -out=/tmp/plan.tmp 2>&1 | tee /tmp/plan.raw
+plan_code=${PIPESTATUS[0]}
+set -e
 echo "plan_exitcode=${plan_code}" >> "${GITHUB_OUTPUT}"
 
 if [ "${plan_code}" -ne 0 ]; then

--- a/actions/terraform-plan/scripts/plan.sh
+++ b/actions/terraform-plan/scripts/plan.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Run terraform plan, capture ITS OWN exit code, and render the result for the PR comment.
+# Extracted from action.yml so it can be shellcheck'd and unit-tested directly.
+#
+# Any real failure (a plan error, or a failing show/cp) exits non-zero, so the step's
+# outcome is 'failure' and the gate catches it. The plan itself is allowed to exit non-zero
+# without aborting - an error is reported through the comment, not just crashed.
+#
+# Reads: REFRESH, GITHUB_OUTPUT. Writes: /tmp/plan.out (kept for the comment step).
+set -euo pipefail
+
+trap 'rm -f /tmp/plan.tmp /tmp/plan.raw' EXIT
+
+plan_code=0
+terraform plan -input=false -no-color -lock=false -refresh="${REFRESH}" -out=/tmp/plan.tmp 2>&1 | tee /tmp/plan.raw || plan_code=$?
+echo "plan_exitcode=${plan_code}" >> "${GITHUB_OUTPUT}"
+
+if [ "${plan_code}" -ne 0 ]; then
+  cp /tmp/plan.raw /tmp/plan.out
+  exit "${plan_code}"
+fi
+
+# Success: render the plan file. A show failure aborts under set -e -> outcome=failure.
+terraform show -no-color /tmp/plan.tmp > /tmp/plan.out

--- a/actions/terraform-plan/scripts/plan.sh
+++ b/actions/terraform-plan/scripts/plan.sh
@@ -9,7 +9,7 @@
 # Reads: REFRESH, GITHUB_OUTPUT. Writes: /tmp/plan.out (kept for the comment step).
 set -euo pipefail
 
-trap 'rm -f /tmp/plan.tmp /tmp/plan.raw' EXIT
+trap 'rm -f /tmp/plan.tmp /tmp/plan.raw /tmp/plan.err' EXIT
 
 plan_code=0
 terraform plan -input=false -no-color -lock=false -refresh="${REFRESH}" -out=/tmp/plan.tmp 2>&1 | tee /tmp/plan.raw || plan_code=$?
@@ -20,5 +20,12 @@ if [ "${plan_code}" -ne 0 ]; then
   exit "${plan_code}"
 fi
 
-# Success: render the plan file. A show failure aborts under set -e -> outcome=failure.
-terraform show -no-color /tmp/plan.tmp > /tmp/plan.out
+# Success: render the plan. On the happy path plan.out is the show stdout only (no stderr
+# warnings polluting the comment); only if show fails do we append its stderr, so the error
+# still surfaces in the comment, then exit non-zero -> outcome=failure -> the gate fires.
+show_code=0
+terraform show -no-color /tmp/plan.tmp > /tmp/plan.out 2>/tmp/plan.err || show_code=$?
+if [ "${show_code}" -ne 0 ]; then
+  cat /tmp/plan.err >> /tmp/plan.out
+  exit "${show_code}"
+fi

--- a/actions/terraform-plan/scripts/post-comment.js
+++ b/actions/terraform-plan/scripts/post-comment.js
@@ -74,7 +74,9 @@ ${validationOutput}
   }
 
   // Resolve the PR: a valid pr_number wins; otherwise the event's PR. Fail loudly rather than
-  // posting onto the wrong PR (or undefined) - the step `if:` trims pr_number the same way.
+  // posting onto the wrong PR (or undefined). The step `if:` only checks pr_number != '' (no
+  // trim), so a whitespace-only value reaches here and trims to empty - hence the fallback +
+  // guard below.
   const raw = (env.PLAN_PR_NUMBER || '').trim();
   let issue_number;
   if (raw !== '') {

--- a/actions/terraform-plan/scripts/post-comment.js
+++ b/actions/terraform-plan/scripts/post-comment.js
@@ -1,0 +1,99 @@
+'use strict';
+
+// Posts the terraform plan result as a PR comment. Extracted from action.yml so it can be
+// linted and unit-tested directly. Inputs arrive via env (PLAN_*) - never interpolated into
+// the caller's `script:` body, which would be a script-injection vector. Invoked as:
+//   require(`${process.env.GITHUB_ACTION_PATH}/scripts/post-comment.js`)({ github, context })
+
+const fs = require('fs');
+
+const MAX_COMMENT_LENGTH = 65536; // GitHub comment body cap
+
+module.exports = async ({ github, context }) => {
+  const env = process.env;
+  const environment = env.PLAN_ENVIRONMENT.toUpperCase();
+  const workingDir = env.PLAN_WORKING_DIR;
+  const sticky = env.PLAN_COMMENT_MODE === 'sticky';
+
+  // Trimmed so a padded marker still matches. Default keys on environment+working_dir so
+  // concurrent plans on one PR keep separate comments.
+  const marker = (env.PLAN_COMMENT_MARKER || '').trim() ||
+    `<!-- terraform-plan:${env.PLAN_ENVIRONMENT}:${workingDir} -->`;
+  // Sticky comments are matched on their first line, so a multi-line marker never matches.
+  if (sticky && /[\r\n]/.test(marker)) {
+    throw new Error('comment_marker must be a single line');
+  }
+
+  const readFile = (p) => (fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '');
+  const esc = (s) => s.replace(/`/g, '\\`');
+  const validationOutput = esc(readFile('/tmp/validate_output.txt'));
+  // May be absent if an earlier step failed before the plan ran; post a notice rather than crash.
+  const plan = fs.existsSync('/tmp/plan.out')
+    ? esc(readFile('/tmp/plan.out'))
+    : 'Plan did not run - an earlier step failed. See the workflow logs.';
+
+  // Values that render inside inline-code spans; an embedded backtick would break the span.
+  const inline = (v) => String(v ?? '').replace(/`/g, '\\`');
+  const footer = `\n\`\`\`\n\n</details>\n\n*Pusher: @${env.PLAN_ACTOR}, Action: \`${inline(env.PLAN_EVENT_NAME)}\`, Working Directory: \`${inline(workingDir)}\`, Workflow: \`${inline(env.PLAN_WORKFLOW)}\`*`;
+  const header = `${sticky ? marker + '\n' : ''}#### Environment: ${environment}
+#### Terraform Initialization ⚙️\`${env.PLAN_INIT_OUTCOME}\`
+#### Terraform Validation 🤖\`${env.PLAN_VALIDATE_OUTCOME}\`
+<details><summary>Validation Output</summary>
+
+\`\`\`\n
+${validationOutput}
+\`\`\`
+
+</details>
+
+#### Terraform Plan 📖\`${env.PLAN_PLAN_OUTCOME}\`
+
+<details><summary>Show Plan</summary>
+
+\`\`\`\n
+`;
+
+  const baseLength = header.length + footer.length;
+  let output;
+  if (baseLength + plan.length > MAX_COMMENT_LENGTH) {
+    const available = MAX_COMMENT_LENGTH - baseLength;
+    // Size the notice against a placeholder first: its length depends on the number it reports.
+    const notice = (n) => `\n\n... [Plan truncated - showing first ${n} characters only. See workflow logs for full output.] ...`;
+    const maxPlan = available - notice(available).length;
+    output = maxPlan > 0
+      ? `${header}${plan.substring(0, maxPlan)}${notice(maxPlan)}${footer}`
+      : `${sticky ? marker + '\n' : ''}#### Environment: ${environment}\n\n#### Terraform Plan 📖\`${env.PLAN_PLAN_OUTCOME}\`\n\nPlan output is too large to display. Please check the workflow logs for the full plan.\n\n*Pusher: @${env.PLAN_ACTOR}*`;
+  } else {
+    output = `${header}${plan}${footer}`;
+  }
+
+  // Resolve the PR: a valid pr_number wins; otherwise the event's PR. Fail loudly rather than
+  // posting onto the wrong PR (or undefined) - the step `if:` trims pr_number the same way.
+  const raw = (env.PLAN_PR_NUMBER || '').trim();
+  let issue_number;
+  if (raw !== '') {
+    issue_number = Number(raw);
+    if (!Number.isInteger(issue_number) || issue_number <= 0) {
+      throw new Error(`pr_number must be a positive integer, got "${raw}"`);
+    }
+  } else {
+    issue_number = context.issue.number;
+    if (!Number.isInteger(issue_number) || issue_number <= 0) {
+      throw new Error('no pull request to comment on: pass a valid pr_number when running outside a pull_request event');
+    }
+  }
+  const { owner, repo } = context.repo;
+
+  if (sticky) {
+    // per_page 100: the default 30 can miss the marker on a busy PR and create a duplicate.
+    const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 });
+    // Match the marker as the first line only: the plan text is embedded verbatim, so a
+    // substring match could latch onto a comment that merely quotes the marker.
+    const existing = comments.find((c) => c.body && c.body.split('\n')[0].trim() === marker);
+    if (existing) {
+      await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: output });
+      return;
+    }
+  }
+  await github.rest.issues.createComment({ owner, repo, issue_number, body: output });
+};

--- a/actions/terraform-plan/scripts/post-comment.js
+++ b/actions/terraform-plan/scripts/post-comment.js
@@ -39,7 +39,8 @@ module.exports = async ({ github, context }) => {
 
   // Values that render inside inline-code spans; an embedded backtick would break the span.
   const inline = (v) => String(v ?? '').replace(/`/g, '\\`');
-  const footer = `\n\`\`\`\n\n</details>\n\n*Pusher: @${env.PLAN_ACTOR}, Action: \`${inline(env.PLAN_EVENT_NAME)}\`, Working Directory: \`${inline(workingDir)}\`, Workflow: \`${inline(env.PLAN_WORKFLOW)}\`*`;
+  const meta = `*Pusher: @${env.PLAN_ACTOR}, Action: \`${inline(env.PLAN_EVENT_NAME)}\`, Working Directory: \`${inline(workingDir)}\`, Workflow: \`${inline(env.PLAN_WORKFLOW)}\`*`;
+  const footer = `\n\`\`\`\n\n</details>\n\n${meta}`;
   const header = `${sticky ? marker + '\n' : ''}#### Environment: ${environment}
 #### Terraform Initialization ⚙️\`${env.PLAN_INIT_OUTCOME}\`
 #### Terraform Validation 🤖\`${env.PLAN_VALIDATE_OUTCOME}\`
@@ -67,7 +68,7 @@ ${validationOutput}
     const maxPlan = available - notice(available).length;
     output = maxPlan > 0
       ? `${header}${plan.substring(0, maxPlan)}${notice(maxPlan)}${footer}`
-      : `${sticky ? marker + '\n' : ''}#### Environment: ${environment}\n\n#### Terraform Plan 📖\`${env.PLAN_PLAN_OUTCOME}\`\n\nPlan output is too large to display. Please check the workflow logs for the full plan.\n\n*Pusher: @${env.PLAN_ACTOR}*`;
+      : `${sticky ? marker + '\n' : ''}#### Environment: ${environment}\n\n#### Terraform Plan 📖\`${env.PLAN_PLAN_OUTCOME}\`\n\nPlan output is too large to display. Please check the workflow logs for the full plan.\n\n${meta}`;
   } else {
     output = `${header}${plan}${footer}`;
   }

--- a/actions/terraform-plan/scripts/post-comment.js
+++ b/actions/terraform-plan/scripts/post-comment.js
@@ -24,13 +24,18 @@ module.exports = async ({ github, context }) => {
     throw new Error('comment_marker must be a single line');
   }
 
-  const readFile = (p) => (fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '');
+  // Read then remove the temp files (consistent with the repo's other actions).
+  const consume = (p) => {
+    if (!fs.existsSync(p)) return '';
+    const v = fs.readFileSync(p, 'utf8');
+    fs.rmSync(p, { force: true });
+    return v;
+  };
   const esc = (s) => s.replace(/`/g, '\\`');
-  const validationOutput = esc(readFile('/tmp/validate_output.txt'));
+  const validationOutput = esc(consume('/tmp/validate_output.txt'));
   // May be absent if an earlier step failed before the plan ran; post a notice rather than crash.
-  const plan = fs.existsSync('/tmp/plan.out')
-    ? esc(readFile('/tmp/plan.out'))
-    : 'Plan did not run - an earlier step failed. See the workflow logs.';
+  const planRaw = consume('/tmp/plan.out');
+  const plan = planRaw ? esc(planRaw) : 'Plan did not run - an earlier step failed. See the workflow logs.';
 
   // Values that render inside inline-code spans; an embedded backtick would break the span.
   const inline = (v) => String(v ?? '').replace(/`/g, '\\`');

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -110,6 +110,16 @@ test('the gate reads plan_exitcode and the step outcome, not the wrapper exitcod
   );
 });
 
+test('the comment step runs on failure so a failed plan still posts its error', () => {
+  const action = fs.readFileSync(ACTION, 'utf8');
+  const m = action.match(/Post Terraform Plan Results to PR[\s\S]*?if:\s*(.+)/);
+  assert.ok(m, 'comment step if: not found');
+  assert.ok(
+    /always\(\)/.test(m[1]),
+    'comment step must use always() - the gate exits 1 first, else the failure comment is skipped',
+  );
+});
+
 test('a successful plan records exit 0 and renders via terraform show', () => {
   const { plan_exitcode, planOut, stepFailed, tmpLeaked } = runPlanStep(0);
   assert.strictEqual(plan_exitcode, '0');

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -83,6 +83,7 @@ test('a show failure after a clean plan fails the step (caught by the outcome ga
   const r = runPlan(0, 1);
   assert.strictEqual(r.plan_exitcode, '0', 'the plan itself succeeded');
   assert.ok(r.stepFailed, 'a failing show must fail the step');
+  assert.ok(r.planOut && r.planOut.includes('show failed'), 'show stderr appended to plan.out on failure');
   assert.ok(!r.tmpLeaked, 'temp files cleaned even on early abort');
 });
 

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -86,6 +86,13 @@ exit 0
   const planOut = fs.existsSync('/tmp/plan.out') ? fs.readFileSync('/tmp/plan.out', 'utf8') : null;
   const tmpLeaked = fs.existsSync('/tmp/plan.tmp') || fs.existsSync('/tmp/plan.raw');
   const m = ghOutput.match(/plan_exitcode=(\d+)/);
+
+  // Read tmpLeaked before this: clean our own scratch so repeated local runs don't pile up
+  // plan-gate-* dirs, and don't leave the fixed /tmp/plan.* paths behind for the next test.
+  fs.rmSync(dir, { recursive: true, force: true });
+  for (const f of ['/tmp/plan.tmp', '/tmp/plan.raw', '/tmp/plan.out']) {
+    fs.rmSync(f, { force: true });
+  }
   return { plan_exitcode: m ? m[1] : null, planOut, stepFailed: threw, tmpLeaked };
 }
 

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -138,11 +138,13 @@ test('a failed plan records its real exit code, not the show exit code', () => {
 test('a show that fails after a clean plan still fails the step (outcome gate catches it)', () => {
   // plan exits 0, show exits 1: under -e the step aborts, so plan_exitcode stays 0 but the
   // step fails -> the runner marks outcome=failure and the gate fires on it.
-  const { plan_exitcode, stepFailed, tmpLeaked } = runPlanStep(0, 1);
+  const { plan_exitcode, planOut, stepFailed, tmpLeaked } = runPlanStep(0, 1);
   assert.strictEqual(plan_exitcode, '0', 'the plan itself succeeded, so plan_exitcode is 0');
   assert.ok(stepFailed, 'a failing show must fail the step so the outcome gate can catch it');
   // set -e aborts before any trailing rm, so cleanup must be trap-based to survive here.
   assert.ok(!tmpLeaked, 'temp files must be cleaned even when the step aborts early');
+  // show writes its error to stderr; without 2>&1 plan.out is empty and the comment blank.
+  assert.ok(planOut && planOut.includes('show failed'), 'show stderr must be captured into plan.out');
 });
 
 console.log('\n' + '='.repeat(50));

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -36,12 +36,15 @@ function extractRunBlock(stepName) {
   return body.join('\n');
 }
 
-/** Run the plan step with a fake terraform whose `plan` exits with `planCode`. */
-function runPlanStep(planCode) {
+/**
+ * Run the plan step with a fake terraform whose `plan` exits `planCode` and `show` exits
+ * `showCode`. The script runs under the SAME shell flags GitHub Actions uses for a bash
+ * step (`-e -o pipefail`), so shell-behavior regressions (e.g. a failing `show` aborting
+ * the step) are exercised the way the runner would see them.
+ */
+function runPlanStep(planCode, showCode = 0) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-gate-'));
   const bin = path.join(dir, 'terraform');
-  // Fake terraform: `plan` writes the out-file (on success) and exits planCode; `show`
-  // renders. Mirrors the real contract the step depends on.
   fs.writeFileSync(bin, `#!/usr/bin/env bash
 cmd="$1"
 if [ "$cmd" = "plan" ]; then
@@ -53,8 +56,8 @@ if [ "$cmd" = "plan" ]; then
   fi
   exit ${planCode}
 elif [ "$cmd" = "show" ]; then
-  echo "rendered plan from show"
-  exit 0
+  if [ "${showCode}" -eq 0 ]; then echo "rendered plan from show"; else echo "show failed" >&2; fi
+  exit ${showCode}
 fi
 exit 0
 `);
@@ -68,15 +71,22 @@ exit 0
     try { fs.unlinkSync(f); } catch { /* ignore */ }
   }
 
-  execFileSync('bash', ['-c', script], {
-    env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, GITHUB_OUTPUT: outFile },
-    stdio: 'pipe',
-  });
+  // GitHub Actions runs a bash `run:` step as `bash --noprofile --norc -e -o pipefail`.
+  let threw = false;
+  try {
+    execFileSync('bash', ['--noprofile', '--norc', '-e', '-o', 'pipefail', '-c', script], {
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, GITHUB_OUTPUT: outFile },
+      stdio: 'pipe',
+    });
+  } catch {
+    threw = true; // non-zero exit -> the runner would mark steps.plan.outcome == 'failure'
+  }
 
   const ghOutput = fs.readFileSync(outFile, 'utf8');
   const planOut = fs.existsSync('/tmp/plan.out') ? fs.readFileSync('/tmp/plan.out', 'utf8') : null;
+  const tmpLeaked = fs.existsSync('/tmp/plan.tmp') || fs.existsSync('/tmp/plan.raw');
   const m = ghOutput.match(/plan_exitcode=(\d+)/);
-  return { plan_exitcode: m ? m[1] : null, planOut };
+  return { plan_exitcode: m ? m[1] : null, planOut, stepFailed: threw, tmpLeaked };
 }
 
 let passed = 0;
@@ -88,28 +98,39 @@ function test(name, fn) {
 
 console.log('Running plan-gate tests...\n');
 
-test('the gate reads plan_exitcode, not the wrapper-provided exitcode', () => {
+test('the gate reads plan_exitcode and the step outcome, not the wrapper exitcode', () => {
   const action = fs.readFileSync(ACTION, 'utf8');
   assert.ok(
-    /if:\s*steps\.plan\.outputs\.plan_exitcode\s*!=\s*'0'/.test(action),
-    'Check for Plan Failure must gate on the explicitly-captured plan_exitcode',
+    /if:\s*steps\.plan\.outputs\.plan_exitcode\s*!=\s*'0'\s*\|\|\s*steps\.plan\.outcome\s*==\s*'failure'/.test(action),
+    'gate must key off the captured plan_exitcode AND the step outcome',
   );
   assert.ok(
-    !/if:\s*steps\.plan\.outputs\.exitcode\s*==\s*1/.test(action),
+    !/steps\.plan\.outputs\.exitcode\s*==\s*1/.test(action),
     'the old wrapper-based gate must be gone',
   );
 });
 
 test('a successful plan records exit 0 and renders via terraform show', () => {
-  const { plan_exitcode, planOut } = runPlanStep(0);
+  const { plan_exitcode, planOut, stepFailed, tmpLeaked } = runPlanStep(0);
   assert.strictEqual(plan_exitcode, '0');
+  assert.ok(!stepFailed, 'a clean plan+show should not fail the step');
   assert.ok(planOut && planOut.includes('rendered plan from show'), 'plan.out should hold the show render');
+  assert.ok(!tmpLeaked, 'plan.tmp / plan.raw must be cleaned up');
 });
 
 test('a failed plan records its real exit code, not the show exit code', () => {
-  const { plan_exitcode, planOut } = runPlanStep(1);
+  const { plan_exitcode, planOut, tmpLeaked } = runPlanStep(1);
   assert.strictEqual(plan_exitcode, '1', 'must capture the plan exit code (1), not show (0)');
   assert.ok(planOut && planOut.includes('something broke'), 'failure output must be preserved for the comment');
+  assert.ok(!tmpLeaked, 'plan.tmp / plan.raw must be cleaned up on the failure path too');
+});
+
+test('a show that fails after a clean plan still fails the step (outcome gate catches it)', () => {
+  // plan exits 0, show exits 1: under -e the step aborts, so plan_exitcode stays 0 but the
+  // step fails -> the runner marks outcome=failure and the gate fires on it.
+  const { plan_exitcode, stepFailed } = runPlanStep(0, 1);
+  assert.strictEqual(plan_exitcode, '0', 'the plan itself succeeded, so plan_exitcode is 0');
+  assert.ok(stepFailed, 'a failing show must fail the step so the outcome gate can catch it');
 });
 
 console.log('\n' + '='.repeat(50));

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -1,12 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Unit test for the terraform-plan failure gate.
- *
- * Extracts and executes the real "Terraform Plan" step script from
- * actions/terraform-plan/action.yml with a fake `terraform` on PATH, so the test verifies
- * the action's actual exit-code capture rather than a mirror of it. The gate must record
- * the plan's OWN exit code (not the trailing `terraform show`'s) so a failed plan is caught.
+ * Tests for the terraform-plan failure gate. Runs the REAL scripts/plan.sh against a fake
+ * terraform, so the exit-code capture and cleanup are exercised, not mirrored.
  *
  * Usage: node tests/test-plan-gate.js
  */
@@ -17,146 +13,80 @@ const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-const ACTION = path.join(__dirname, '..', 'actions', 'terraform-plan', 'action.yml');
+const ROOT = path.join(__dirname, '..');
+const PLAN_SH = path.join(ROOT, 'actions', 'terraform-plan', 'scripts', 'plan.sh');
+const ACTION = path.join(ROOT, 'actions', 'terraform-plan', 'action.yml');
 
-/** Extract a named step's `run: |` block from the action, dedented as the runner would. */
-function extractRunBlock(stepName) {
-  const lines = fs.readFileSync(ACTION, 'utf8').split('\n');
-  const nameIdx = lines.findIndex((l) => l.trim() === `- name: ${stepName}`);
-  assert.ok(nameIdx !== -1, `step "${stepName}" not found`);
-  const runIdx = lines.findIndex((l, i) => i > nameIdx && l.trim() === 'run: |');
-  assert.ok(runIdx !== -1, `run block for "${stepName}" not found`);
-
-  const body = [];
-  const indent = lines[runIdx].search(/\S/) + 2;
-  for (const line of lines.slice(runIdx + 1)) {
-    if (line.trim() !== '' && line.search(/\S/) < indent) break;
-    body.push(line.slice(indent));
-  }
-  return body.join('\n');
-}
-
-/**
- * Run the plan step with a fake terraform whose `plan` exits `planCode` and `show` exits
- * `showCode`. The script runs under the SAME shell flags GitHub Actions uses for a bash
- * step (`-e -o pipefail`), so shell-behavior regressions (e.g. a failing `show` aborting
- * the step) are exercised the way the runner would see them.
- */
-function runPlanStep(planCode, showCode = 0) {
+/** Run plan.sh with a fake terraform whose plan/show exit with the given codes. */
+function runPlan(planCode, showCode = 0) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-gate-'));
-  const bin = path.join(dir, 'terraform');
-  fs.writeFileSync(bin, `#!/usr/bin/env bash
-cmd="$1"
-if [ "$cmd" = "plan" ]; then
-  if [ "${planCode}" -eq 0 ]; then
-    echo "Plan: 1 to add, 0 to change, 0 to destroy."
-    : > /tmp/plan.tmp
-  else
-    echo "Error: something broke" >&2
-  fi
-  exit ${planCode}
-elif [ "$cmd" = "show" ]; then
-  if [ "${showCode}" -eq 0 ]; then echo "rendered plan from show"; else echo "show failed" >&2; fi
-  exit ${showCode}
-fi
+  fs.writeFileSync(path.join(dir, 'terraform'), `#!/usr/bin/env bash
+case "$1" in
+  plan) [ "${planCode}" -eq 0 ] && { echo "Plan: 1 to add"; : > /tmp/plan.tmp; } || echo "Error: broke" >&2; exit ${planCode} ;;
+  show) [ "${showCode}" -eq 0 ] && echo "rendered plan" || { echo "show failed" >&2; exit ${showCode}; }; exit 0 ;;
+esac
 exit 0
 `);
-  fs.chmodSync(bin, 0o755);
-
+  fs.chmodSync(path.join(dir, 'terraform'), 0o755);
   const outFile = path.join(dir, 'gh_output');
   fs.writeFileSync(outFile, '');
-  const script = extractRunBlock('Terraform Plan').replace(/\$\{\{ inputs\.refresh \}\}/g, 'true');
+  for (const f of ['/tmp/plan.tmp', '/tmp/plan.raw', '/tmp/plan.out']) fs.rmSync(f, { force: true });
 
-  for (const f of ['/tmp/plan.tmp', '/tmp/plan.raw', '/tmp/plan.out']) {
-    try { fs.unlinkSync(f); } catch { /* ignore */ }
-  }
-
-  // GitHub Actions runs a bash `run:` step as `bash --noprofile --norc -e -o pipefail`.
-  let threw = false;
+  let stepFailed = false;
   try {
-    execFileSync('bash', ['--noprofile', '--norc', '-e', '-o', 'pipefail', '-c', script], {
-      env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, GITHUB_OUTPUT: outFile },
+    execFileSync('bash', [PLAN_SH], {
+      cwd: dir,
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, GITHUB_OUTPUT: outFile, REFRESH: 'true' },
       stdio: 'pipe',
     });
-  } catch {
-    threw = true; // non-zero exit -> the runner would mark steps.plan.outcome == 'failure'
-  }
+  } catch { stepFailed = true; }
 
-  const ghOutput = fs.readFileSync(outFile, 'utf8');
+  const m = fs.readFileSync(outFile, 'utf8').match(/plan_exitcode=(\d+)/);
   const planOut = fs.existsSync('/tmp/plan.out') ? fs.readFileSync('/tmp/plan.out', 'utf8') : null;
   const tmpLeaked = fs.existsSync('/tmp/plan.tmp') || fs.existsSync('/tmp/plan.raw');
-  const m = ghOutput.match(/plan_exitcode=(\d+)/);
-
-  // Read tmpLeaked before this: clean our own scratch so repeated local runs don't pile up
-  // plan-gate-* dirs, and don't leave the fixed /tmp/plan.* paths behind for the next test.
   fs.rmSync(dir, { recursive: true, force: true });
-  for (const f of ['/tmp/plan.tmp', '/tmp/plan.raw', '/tmp/plan.out']) {
-    fs.rmSync(f, { force: true });
-  }
-  return { plan_exitcode: m ? m[1] : null, planOut, stepFailed: threw, tmpLeaked };
+  for (const f of ['/tmp/plan.tmp', '/tmp/plan.raw', '/tmp/plan.out']) fs.rmSync(f, { force: true });
+  return { plan_exitcode: m ? m[1] : null, planOut, stepFailed, tmpLeaked };
 }
 
-let passed = 0;
-let failed = 0;
+let passed = 0, failed = 0;
 function test(name, fn) {
   try { fn(); console.log(`✓ PASSED  ${name}`); passed++; }
-  catch (err) { console.log(`✗ FAILED  ${name}\n   ${err.message}`); failed++; }
+  catch (e) { console.log(`✗ FAILED  ${name}\n   ${e.message}`); failed++; }
 }
 
 console.log('Running plan-gate tests...\n');
 
-test('the gate reads plan_exitcode and the step outcome, not the wrapper exitcode', () => {
-  const action = fs.readFileSync(ACTION, 'utf8');
-  assert.ok(
-    /if:\s*steps\.plan\.outputs\.plan_exitcode\s*!=\s*'0'\s*\|\|\s*steps\.plan\.outcome\s*==\s*'failure'/.test(action),
-    'gate must key off the captured plan_exitcode AND the step outcome',
-  );
-  assert.ok(
-    !/steps\.plan\.outputs\.exitcode\s*==\s*1/.test(action),
-    'the old wrapper-based gate must be gone',
-  );
+test('gate keys off the step outcome, and comment skips a pre-plan failure', () => {
+  const a = fs.readFileSync(ACTION, 'utf8');
+  assert.ok(/if:\s*steps\.plan\.outcome\s*==\s*'failure'/.test(a), 'gate must be steps.plan.outcome == failure');
+  assert.ok(/steps\.plan\.outcome\s*!=\s*'skipped'/.test(a), 'comment step must skip a pre-plan failure');
 });
 
-test('the comment step runs on failure so a failed plan still posts its error', () => {
-  const action = fs.readFileSync(ACTION, 'utf8');
-  const m = action.match(/Post Terraform Plan Results to PR[\s\S]*?if:\s*(.+)/);
-  assert.ok(m, 'comment step if: not found');
-  assert.ok(
-    /always\(\)/.test(m[1]),
-    'comment step must use always() - the gate exits 1 first, else the failure comment is skipped',
-  );
+test('a successful plan records exit 0, renders via show, no leak', () => {
+  const r = runPlan(0);
+  assert.strictEqual(r.plan_exitcode, '0');
+  assert.ok(!r.stepFailed, 'clean plan+show should not fail the step');
+  assert.ok(r.planOut && r.planOut.includes('rendered plan'), 'plan.out holds the show render');
+  assert.ok(!r.tmpLeaked, 'plan.tmp/plan.raw cleaned');
 });
 
-test('a successful plan records exit 0 and renders via terraform show', () => {
-  const { plan_exitcode, planOut, stepFailed, tmpLeaked } = runPlanStep(0);
-  assert.strictEqual(plan_exitcode, '0');
-  assert.ok(!stepFailed, 'a clean plan+show should not fail the step');
-  assert.ok(planOut && planOut.includes('rendered plan from show'), 'plan.out should hold the show render');
-  assert.ok(!tmpLeaked, 'plan.tmp / plan.raw must be cleaned up');
+test('a failed plan records its own exit code and preserves output, no leak', () => {
+  const r = runPlan(1);
+  assert.strictEqual(r.plan_exitcode, '1', 'captures the plan exit code');
+  assert.ok(r.stepFailed, 'a failed plan fails the step');
+  assert.ok(r.planOut && r.planOut.includes('broke'), 'failure output preserved for the comment');
+  assert.ok(!r.tmpLeaked, 'temp files cleaned on the failure path');
 });
 
-test('a failed plan records its real exit code, not the show exit code', () => {
-  const { plan_exitcode, planOut, tmpLeaked } = runPlanStep(1);
-  assert.strictEqual(plan_exitcode, '1', 'must capture the plan exit code (1), not show (0)');
-  assert.ok(planOut && planOut.includes('something broke'), 'failure output must be preserved for the comment');
-  assert.ok(!tmpLeaked, 'plan.tmp / plan.raw must be cleaned up on the failure path too');
-});
-
-test('a show that fails after a clean plan still fails the step (outcome gate catches it)', () => {
-  // plan exits 0, show exits 1: under -e the step aborts, so plan_exitcode stays 0 but the
-  // step fails -> the runner marks outcome=failure and the gate fires on it.
-  const { plan_exitcode, planOut, stepFailed, tmpLeaked } = runPlanStep(0, 1);
-  assert.strictEqual(plan_exitcode, '0', 'the plan itself succeeded, so plan_exitcode is 0');
-  assert.ok(stepFailed, 'a failing show must fail the step so the outcome gate can catch it');
-  // set -e aborts before any trailing rm, so cleanup must be trap-based to survive here.
-  assert.ok(!tmpLeaked, 'temp files must be cleaned even when the step aborts early');
-  // show writes its error to stderr; without 2>&1 plan.out is empty and the comment blank.
-  assert.ok(planOut && planOut.includes('show failed'), 'show stderr must be captured into plan.out');
+test('a show failure after a clean plan fails the step (caught by the outcome gate), no leak', () => {
+  const r = runPlan(0, 1);
+  assert.strictEqual(r.plan_exitcode, '0', 'the plan itself succeeded');
+  assert.ok(r.stepFailed, 'a failing show must fail the step');
+  assert.ok(!r.tmpLeaked, 'temp files cleaned even on early abort');
 });
 
 console.log('\n' + '='.repeat(50));
-console.log(`Tests completed: ${passed + failed}`);
-console.log(`Passed: ${passed}`);
-console.log(`Failed: ${failed}`);
+console.log(`Passed: ${passed}\nFailed: ${failed}`);
 console.log('='.repeat(50));
 if (failed > 0) process.exit(1);

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -128,9 +128,11 @@ test('a failed plan records its real exit code, not the show exit code', () => {
 test('a show that fails after a clean plan still fails the step (outcome gate catches it)', () => {
   // plan exits 0, show exits 1: under -e the step aborts, so plan_exitcode stays 0 but the
   // step fails -> the runner marks outcome=failure and the gate fires on it.
-  const { plan_exitcode, stepFailed } = runPlanStep(0, 1);
+  const { plan_exitcode, stepFailed, tmpLeaked } = runPlanStep(0, 1);
   assert.strictEqual(plan_exitcode, '0', 'the plan itself succeeded, so plan_exitcode is 0');
   assert.ok(stepFailed, 'a failing show must fail the step so the outcome gate can catch it');
+  // set -e aborts before any trailing rm, so cleanup must be trap-based to survive here.
+  assert.ok(!tmpLeaked, 'temp files must be cleaned even when the step aborts early');
 });
 
 console.log('\n' + '='.repeat(50));

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+/**
+ * Unit test for the terraform-plan failure gate.
+ *
+ * Extracts and executes the real "Terraform Plan" step script from
+ * actions/terraform-plan/action.yml with a fake `terraform` on PATH, so the test verifies
+ * the action's actual exit-code capture rather than a mirror of it. The gate must record
+ * the plan's OWN exit code (not the trailing `terraform show`'s) so a failed plan is caught.
+ *
+ * Usage: node tests/test-plan-gate.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ACTION = path.join(__dirname, '..', 'actions', 'terraform-plan', 'action.yml');
+
+/** Extract a named step's `run: |` block from the action, dedented as the runner would. */
+function extractRunBlock(stepName) {
+  const lines = fs.readFileSync(ACTION, 'utf8').split('\n');
+  const nameIdx = lines.findIndex((l) => l.trim() === `- name: ${stepName}`);
+  assert.ok(nameIdx !== -1, `step "${stepName}" not found`);
+  const runIdx = lines.findIndex((l, i) => i > nameIdx && l.trim() === 'run: |');
+  assert.ok(runIdx !== -1, `run block for "${stepName}" not found`);
+
+  const body = [];
+  const indent = lines[runIdx].search(/\S/) + 2;
+  for (const line of lines.slice(runIdx + 1)) {
+    if (line.trim() !== '' && line.search(/\S/) < indent) break;
+    body.push(line.slice(indent));
+  }
+  return body.join('\n');
+}
+
+/** Run the plan step with a fake terraform whose `plan` exits with `planCode`. */
+function runPlanStep(planCode) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-gate-'));
+  const bin = path.join(dir, 'terraform');
+  // Fake terraform: `plan` writes the out-file (on success) and exits planCode; `show`
+  // renders. Mirrors the real contract the step depends on.
+  fs.writeFileSync(bin, `#!/usr/bin/env bash
+cmd="$1"
+if [ "$cmd" = "plan" ]; then
+  if [ "${planCode}" -eq 0 ]; then
+    echo "Plan: 1 to add, 0 to change, 0 to destroy."
+    : > /tmp/plan.tmp
+  else
+    echo "Error: something broke" >&2
+  fi
+  exit ${planCode}
+elif [ "$cmd" = "show" ]; then
+  echo "rendered plan from show"
+  exit 0
+fi
+exit 0
+`);
+  fs.chmodSync(bin, 0o755);
+
+  const outFile = path.join(dir, 'gh_output');
+  fs.writeFileSync(outFile, '');
+  const script = extractRunBlock('Terraform Plan').replace(/\$\{\{ inputs\.refresh \}\}/g, 'true');
+
+  for (const f of ['/tmp/plan.tmp', '/tmp/plan.raw', '/tmp/plan.out']) {
+    try { fs.unlinkSync(f); } catch { /* ignore */ }
+  }
+
+  execFileSync('bash', ['-c', script], {
+    env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, GITHUB_OUTPUT: outFile },
+    stdio: 'pipe',
+  });
+
+  const ghOutput = fs.readFileSync(outFile, 'utf8');
+  const planOut = fs.existsSync('/tmp/plan.out') ? fs.readFileSync('/tmp/plan.out', 'utf8') : null;
+  const m = ghOutput.match(/plan_exitcode=(\d+)/);
+  return { plan_exitcode: m ? m[1] : null, planOut };
+}
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`✓ PASSED  ${name}`); passed++; }
+  catch (err) { console.log(`✗ FAILED  ${name}\n   ${err.message}`); failed++; }
+}
+
+console.log('Running plan-gate tests...\n');
+
+test('the gate reads plan_exitcode, not the wrapper-provided exitcode', () => {
+  const action = fs.readFileSync(ACTION, 'utf8');
+  assert.ok(
+    /if:\s*steps\.plan\.outputs\.plan_exitcode\s*!=\s*'0'/.test(action),
+    'Check for Plan Failure must gate on the explicitly-captured plan_exitcode',
+  );
+  assert.ok(
+    !/if:\s*steps\.plan\.outputs\.exitcode\s*==\s*1/.test(action),
+    'the old wrapper-based gate must be gone',
+  );
+});
+
+test('a successful plan records exit 0 and renders via terraform show', () => {
+  const { plan_exitcode, planOut } = runPlanStep(0);
+  assert.strictEqual(plan_exitcode, '0');
+  assert.ok(planOut && planOut.includes('rendered plan from show'), 'plan.out should hold the show render');
+});
+
+test('a failed plan records its real exit code, not the show exit code', () => {
+  const { plan_exitcode, planOut } = runPlanStep(1);
+  assert.strictEqual(plan_exitcode, '1', 'must capture the plan exit code (1), not show (0)');
+  assert.ok(planOut && planOut.includes('something broke'), 'failure output must be preserved for the comment');
+});
+
+console.log('\n' + '='.repeat(50));
+console.log(`Tests completed: ${passed + failed}`);
+console.log(`Passed: ${passed}`);
+console.log(`Failed: ${failed}`);
+console.log('='.repeat(50));
+if (failed > 0) process.exit(1);

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -63,6 +63,11 @@ test('gate keys off the step outcome, and comment skips a pre-plan failure', () 
   assert.ok(/steps\.plan\.outcome\s*!=\s*'skipped'/.test(a), 'comment step must skip a pre-plan failure');
 });
 
+test('plan.sh captures terraform own exit code via PIPESTATUS, not the pipeline/tee status', () => {
+  const sh = fs.readFileSync(path.join(ROOT, 'actions', 'terraform-plan', 'scripts', 'plan.sh'), 'utf8');
+  assert.ok(/plan_code=\$\{PIPESTATUS\[0\]\}/.test(sh), 'must read PIPESTATUS[0] so tee cannot mask the plan code');
+});
+
 test('a successful plan records exit 0, renders via show, no leak', () => {
   const r = runPlan(0);
   assert.strictEqual(r.plan_exitcode, '0');

--- a/tests/test-refresh-configuration.js
+++ b/tests/test-refresh-configuration.js
@@ -36,7 +36,12 @@ function runTests() {
   console.log('Running refresh configuration tests...\n');
 
   assertHasRefreshInput('actions/terraform-plan/action.yml', 'Whether to refresh the state before planning');
-  assertTerraformCommandUsesRefresh('actions/terraform-plan/action.yml', 'terraform plan');
+  // terraform-plan runs the plan from scripts/plan.sh: action.yml passes inputs.refresh as
+  // the REFRESH env, and plan.sh uses it.
+  const planAction = readAction('actions/terraform-plan/action.yml');
+  assert.match(planAction, /REFRESH: \$\{\{ inputs\.refresh \}\}/, 'action.yml should pass inputs.refresh as REFRESH env');
+  const planSh = fs.readFileSync(path.join(ROOT, 'actions', 'terraform-plan', 'scripts', 'plan.sh'), 'utf8');
+  assert.match(planSh, /terraform plan[^\n]*-refresh="\$\{REFRESH\}"/, 'plan.sh should pass REFRESH to terraform plan');
 
   assertHasRefreshInput('actions/terraform-plan-gcp/action.yml', 'Whether to refresh the state before planning');
   assertTerraformCommandUsesRefresh('actions/terraform-plan-gcp/action.yml', 'terraform plan');

--- a/tests/test-sticky-comment.js
+++ b/tests/test-sticky-comment.js
@@ -40,7 +40,11 @@ async function run({ mode = 'sticky', marker = '', prNumber = '', workingDir = '
       createComment: async (o) => calls.push({ op: 'create', issue: o.issue_number, body: o.body }),
     } },
   };
-  await post({ github, context: { repo: { owner: 'o', repo: 'r' }, issue: { number: contextIssue } } });
+  try {
+    await post({ github, context: { repo: { owner: 'o', repo: 'r' }, issue: { number: contextIssue } } });
+  } finally {
+    for (const f of ['/tmp/plan.out', '/tmp/validate_output.txt']) fs.rmSync(f, { force: true });
+  }
   return { call: calls[0], calls, pageOpts };
 }
 

--- a/tests/test-sticky-comment.js
+++ b/tests/test-sticky-comment.js
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Unit test for sticky PR-comment behaviour (terraform-plan)
- *
- * Unlike the other suites, this one extracts and executes the real script from
- * actions/terraform-plan/action.yml rather than mirroring it, so the test cannot
- * silently drift from the action.
+ * Tests for the plan PR-comment logic. Requires the REAL scripts/post-comment.js module and
+ * calls it with mock github/context, so the test cannot drift from the shipped code.
  *
  * Usage: node tests/test-sticky-comment.js
  */
@@ -14,261 +11,132 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const MAX_COMMENT_LENGTH = 65536;
-const ACTION = path.join(__dirname, '..', 'actions', 'terraform-plan', 'action.yml');
+const ROOT = path.join(__dirname, '..');
+const ACTION = path.join(ROOT, 'actions', 'terraform-plan', 'action.yml');
+const POST = path.join(ROOT, 'actions', 'terraform-plan', 'scripts', 'post-comment.js');
+const post = require(POST);
 
-/**
- * Pull the github-script body out of the action without a YAML dependency: find the
- * comment step's `script: |` block and strip its common indentation, which is what the
- * YAML block scalar does at runtime.
- */
-function extractCommentScript() {
-  const lines = fs.readFileSync(ACTION, 'utf8').split('\n');
-  const start = lines.findIndex((l) => l.includes('script: |'));
-  assert.ok(start !== -1, 'could not find the script block in action.yml');
+const MAX = 65536;
+const DEFAULT_MARKER = '<!-- terraform-plan:staging:live/workloads -->';
 
-  const body = [];
-  const indent = lines[start].search(/\S/) + 2;
-  for (const line of lines.slice(start + 1)) {
-    if (line.trim() !== '' && line.search(/\S/) < indent) break;
-    body.push(line.slice(indent));
-  }
-  return body.join('\n');
-}
-
-/**
- * The action passes every consumer-controlled value through the step's env rather than
- * interpolating it into the script, so the script must contain no ${{ }} expressions -
- * interpolating them would be a script-injection vector. Assert that here: if someone
- * reintroduces one, these tests would silently stop matching the real behaviour.
- */
-function assertNoInterpolation(src) {
-  const found = src.split('\n').filter((l) => l.includes('${{'));
-  assert.strictEqual(
-    found.length, 0,
-    `script must not interpolate expressions (script-injection risk):\n${found.join('\n')}`,
-  );
-}
-
-/** Set the env the action declares on the step. */
-function applyEnv({ mode, marker, prNumber, workingDir }) {
+async function run({ mode = 'sticky', marker = '', prNumber = '', workingDir = 'live/workloads',
+  planSize = 100, existing = [], contextIssue = 5, planExists = true } = {}) {
+  fs.writeFileSync('/tmp/validate_output.txt', 'valid');
+  if (planExists) fs.writeFileSync('/tmp/plan.out', 'P'.repeat(planSize));
+  else fs.rmSync('/tmp/plan.out', { force: true });
   Object.assign(process.env, {
-    PLAN_ENVIRONMENT: 'staging',
-    PLAN_WORKING_DIR: workingDir,
-    PLAN_COMMENT_MODE: mode,
-    PLAN_COMMENT_MARKER: marker,
-    PLAN_PR_NUMBER: prNumber,
-    PLAN_INIT_OUTCOME: 'success',
-    PLAN_VALIDATE_OUTCOME: 'success',
-    PLAN_PLAN_OUTCOME: 'success',
-    PLAN_ACTOR: 'tester',
-    PLAN_EVENT_NAME: 'pull_request',
-    PLAN_WORKFLOW: 'Plan',
+    PLAN_ENVIRONMENT: 'staging', PLAN_WORKING_DIR: workingDir, PLAN_COMMENT_MODE: mode,
+    PLAN_COMMENT_MARKER: marker, PLAN_PR_NUMBER: prNumber, PLAN_INIT_OUTCOME: 'success',
+    PLAN_VALIDATE_OUTCOME: 'success', PLAN_PLAN_OUTCOME: 'success', PLAN_ACTOR: 'tester',
+    PLAN_EVENT_NAME: 'pull_request', PLAN_WORKFLOW: 'Plan',
   });
+  const calls = [];
+  let pageOpts = null;
+  const github = {
+    paginate: async (_fn, o) => { pageOpts = o; return existing; },
+    rest: { issues: {
+      listComments: 'lc',
+      updateComment: async (o) => calls.push({ op: 'update', id: o.comment_id, body: o.body }),
+      createComment: async (o) => calls.push({ op: 'create', issue: o.issue_number, body: o.body }),
+    } },
+  };
+  await post({ github, context: { repo: { owner: 'o', repo: 'r' }, issue: { number: contextIssue } } });
+  return { call: calls[0], calls, pageOpts };
 }
 
-/** Read a declared input default straight out of action.yml (no YAML dependency). */
-function declaredInputDefault(name) {
+function declaredDefault(name) {
   const lines = fs.readFileSync(ACTION, 'utf8').split('\n');
-  const start = lines.findIndex((l) => l.trim() === `${name}:`);
-  assert.ok(start !== -1, `input ${name} not declared in action.yml`);
-  for (const line of lines.slice(start + 1)) {
-    if (/^\s{2}\S/.test(line)) break; // next input
-    const m = line.match(/^\s+default:\s*"?([^"]*)"?\s*$/);
+  const i = lines.findIndex((l) => l.trim() === `${name}:`);
+  for (const l of lines.slice(i + 1)) {
+    if (/^\s{2}\S/.test(l)) break;
+    const m = l.match(/^\s+default:\s*"?([^"]*)"?\s*$/);
     if (m) return m[1];
   }
-  return undefined;
 }
 
-async function runAction({
-  mode = 'sticky',
-  marker = '',
-  prNumber = '',
-  workingDir = 'live/workloads',
-  planSize = 100,
-  existingComments = [],
-  contextIssue = 5,
-}) {
-  fs.writeFileSync('/tmp/validate_output.txt', 'Success! The configuration is valid.');
-  fs.writeFileSync('/tmp/plan.out', 'P'.repeat(planSize));
-
-  const calls = [];
-  let paginateOpts = null;
-  const github = {
-    paginate: async (_fn, opts) => {
-      paginateOpts = opts;
-      return existingComments;
-    },
-    rest: {
-      issues: {
-        listComments: 'listComments',
-        updateComment: async (o) => calls.push({ op: 'update', id: o.comment_id, body: o.body }),
-        createComment: async (o) => calls.push({ op: 'create', issue: o.issue_number, body: o.body }),
-      },
-    },
-  };
-  const context = { repo: { owner: 'o', repo: 'r' }, issue: { number: contextIssue } };
-
-  const src = extractCommentScript();
-  assertNoInterpolation(src);
-  applyEnv({ mode, marker, prNumber, workingDir });
-  await new Function('github', 'context', 'require', `return (async () => {${src}})()`)(github, context, require);
-
-  return { call: calls[0], calls, paginateOpts };
-}
-
-const DEFAULT_MARKER = '<!-- terraform-plan:staging:live/workloads -->';
-let passed = 0;
-let failed = 0;
-
+let passed = 0, failed = 0;
 async function test(name, fn) {
-  try {
-    await fn();
-    console.log(`✓ PASSED  ${name}`);
-    passed++;
-  } catch (err) {
-    console.log(`✗ FAILED  ${name}\n   ${err.message}`);
-    failed++;
-  }
+  try { await fn(); console.log(`✓ PASSED  ${name}`); passed++; }
+  catch (e) { console.log(`✗ FAILED  ${name}\n   ${e.message}`); failed++; }
 }
 
 (async () => {
-  console.log('Running sticky comment tests...\n');
+  console.log('Running post-comment tests...\n');
 
-  await test('comment_mode defaults to sticky', async () => {
-    assert.strictEqual(declaredInputDefault('comment_mode'), 'sticky');
-  });
+  await test('comment_mode defaults to sticky', () => assert.strictEqual(declaredDefault('comment_mode'), 'sticky'));
 
-  await test('comment_marker defaults to empty so the marker is derived', async () => {
-    assert.strictEqual(declaredInputDefault('comment_marker'), '');
-  });
-
-  await test('new mode appends a fresh comment and embeds no marker', async () => {
-    const { call, calls } = await runAction({ mode: 'new' });
+  await test('new mode appends and embeds no marker', async () => {
+    const { call, calls } = await run({ mode: 'new' });
     assert.strictEqual(call.op, 'create');
-    assert.ok(!call.body.includes('terraform-plan:'), 'marker leaked into non-sticky comment');
+    assert.ok(!call.body.includes('terraform-plan:'));
     assert.strictEqual(calls.length, 1);
   });
 
   await test('sticky with no existing comment creates one carrying the marker', async () => {
-    const { call } = await runAction({ mode: 'sticky' });
+    const { call } = await run({ mode: 'sticky' });
     assert.strictEqual(call.op, 'create');
-    assert.ok(call.body.startsWith(DEFAULT_MARKER), 'sticky comment must lead with its marker');
+    assert.ok(call.body.startsWith(DEFAULT_MARKER));
   });
 
   await test('sticky updates the existing comment in place', async () => {
-    const { call } = await runAction({
-      mode: 'sticky',
-      existingComments: [{ id: 7, body: 'unrelated' }, { id: 42, body: `${DEFAULT_MARKER}\nold plan` }],
-    });
+    const { call } = await run({ existing: [{ id: 7, body: 'x' }, { id: 42, body: `${DEFAULT_MARKER}\nold` }] });
     assert.strictEqual(call.op, 'update');
     assert.strictEqual(call.id, 42);
   });
 
-  await test('sticky requests all comment pages (marker must not be missed)', async () => {
-    const { paginateOpts } = await runAction({ mode: 'sticky' });
-    assert.strictEqual(paginateOpts.per_page, 100, 'must page at 100 to avoid duplicate stickies');
+  await test('sticky pages at 100 to avoid duplicate stickies', async () => {
+    const { pageOpts } = await run({ mode: 'sticky' });
+    assert.strictEqual(pageOpts.per_page, 100);
   });
 
   await test('a custom marker is honoured', async () => {
-    const custom = '<!-- tf-plan:staging -->';
-    const { call } = await runAction({
-      mode: 'sticky',
-      marker: custom,
-      existingComments: [{ id: 99, body: `${custom}\nold` }],
-    });
-    assert.strictEqual(call.op, 'update');
+    const c = '<!-- tf-plan:staging -->';
+    const { call } = await run({ marker: c, existing: [{ id: 99, body: `${c}\nold` }] });
     assert.strictEqual(call.id, 99);
   });
 
-  await test('different markers do not collide on the same PR', async () => {
-    const { call } = await runAction({
-      mode: 'sticky',
-      existingComments: [{ id: 11, body: '<!-- terraform-plan:dev:live/workloads -->\ndev plan' }],
-    });
-    assert.strictEqual(call.op, 'create', 'staging must not overwrite the dev sticky comment');
+  await test('a comment merely quoting the marker is not hijacked', async () => {
+    const { call } = await run({ existing: [{ id: 88, body: `quote:\n${DEFAULT_MARKER}\nreply` }] });
+    assert.strictEqual(call.op, 'create');
+  });
+
+  await test('distinct markers do not collide', async () => {
+    const { call } = await run({ existing: [{ id: 11, body: '<!-- terraform-plan:dev:live/workloads -->\ndev' }] });
+    assert.strictEqual(call.op, 'create');
   });
 
   await test('pr_number overrides the event PR', async () => {
-    const { call } = await runAction({ mode: 'new', prNumber: '399', contextIssue: undefined });
-    assert.strictEqual(call.op, 'create');
+    const { call } = await run({ mode: 'new', prNumber: '399', contextIssue: null });
     assert.strictEqual(call.issue, 399);
   });
 
-  await test('a comment merely quoting the marker is not treated as the sticky comment', async () => {
-    const { call } = await runAction({
-      mode: 'sticky',
-      // The plan text is embedded verbatim, so a marker can legitimately appear mid-body.
-      existingComments: [{ id: 88, body: `someone quoted this:\n${DEFAULT_MARKER}\nin their reply` }],
-    });
-    assert.strictEqual(call.op, 'create', 'must not hijack a comment that only mentions the marker');
+  await test('a multi-line marker fails fast', async () => {
+    await assert.rejects(() => run({ marker: '<!-- a\nb -->' }), /single line/);
   });
 
-  await test('a malformed pr_number fails loudly instead of retargeting the event PR', async () => {
-    for (const bad of ['abc', '0', '-3', '1.5']) {
-      await assert.rejects(
-        () => runAction({ mode: 'new', prNumber: bad, contextIssue: 5 }),
-        /pr_number must be a positive integer/,
-        `pr_number "${bad}" should have been rejected`,
-      );
+  await test('a malformed pr_number fails loudly', async () => {
+    for (const bad of ['abc', '0', '-3']) await assert.rejects(() => run({ prNumber: bad }), /positive integer/);
+  });
+
+  await test('a backtick in working_dir cannot break the inline code span', async () => {
+    const { call } = await run({ workingDir: 'a/`x`/b' });
+    assert.ok(call.body.includes('Working Directory: `a/\\`x\\`/b`'));
+  });
+
+  await test('comment stays within the GitHub limit', async () => {
+    for (const s of [60000, 100000, 500000]) {
+      const { call } = await run({ planSize: s });
+      assert.ok(call.body.length <= MAX, `size ${s} -> ${call.body.length}`);
     }
   });
 
-  await test('an empty pr_number falls back to the event PR', async () => {
-    const { call } = await runAction({ mode: 'new', prNumber: '   ', contextIssue: 12 });
-    assert.strictEqual(call.issue, 12);
-  });
-
-  await test('a multi-line comment_marker fails fast instead of never matching', async () => {
-    // Matching compares the comment's first line, so a multi-line marker could never match
-    // and would silently post a new comment every run.
-    for (const bad of ['<!-- a\nb -->', '<!-- a\r\nb -->']) {
-      await assert.rejects(
-        () => runAction({ mode: 'sticky', marker: bad }),
-        /comment_marker must be a single line/,
-      );
-    }
-  });
-
-  await test('backticks in working_dir cannot break out of the inline code span', async () => {
-    const { call } = await runAction({ mode: 'sticky', workingDir: 'live/`rm -rf`/workloads' });
-    assert.ok(
-      call.body.includes('Working Directory: `live/\\`rm -rf\\`/workloads`'),
-      `backtick was not escaped in the footer:\n${call.body.slice(-200)}`,
-    );
-  });
-
-  await test('whitespace-only pr_number off a PR event fails clearly, not at the API', async () => {
-    // The step-level `if:` treats "   " as non-empty and lets the step run, but the script
-    // trims it away - without a guard this reaches the API as an undefined issue number.
-    // null, not undefined: a default parameter would swallow undefined and hand the script
-    // a valid PR number, making this assertion vacuous.
-    await assert.rejects(
-      () => runAction({ mode: 'new', prNumber: '   ', contextIssue: null }),
-      /no pull request to comment on/,
-    );
-  });
-
-  await test('sticky comment stays within the GitHub comment limit', async () => {
-    for (const planSize of [60000, 65000, 100000, 500000]) {
-      const { call } = await runAction({ mode: 'sticky', planSize });
-      assert.ok(
-        call.body.length <= MAX_COMMENT_LENGTH,
-        `plan ${planSize} produced ${call.body.length} chars (limit ${MAX_COMMENT_LENGTH})`,
-      );
-    }
-  });
-
-  await test('a plan that fits is not truncated just to reserve room for the notice', async () => {
-    const { call } = await runAction({ mode: 'sticky', planSize: 100 });
-    assert.ok(!call.body.includes('Plan truncated'), 'small plan should not be truncated');
+  await test('a missing plan.out posts a notice, not a crash', async () => {
+    const { call } = await run({ planExists: false });
+    assert.ok(call.body.includes('Plan did not run'));
   });
 
   console.log('\n' + '='.repeat(50));
-  console.log(`Tests completed: ${passed + failed}`);
-  console.log(`Passed: ${passed}`);
-  console.log(`Failed: ${failed}`);
+  console.log(`Passed: ${passed}\nFailed: ${failed}`);
   console.log('='.repeat(50));
-
   if (failed > 0) process.exit(1);
 })();

--- a/tests/test-sticky-comment.js
+++ b/tests/test-sticky-comment.js
@@ -47,6 +47,7 @@ async function run({ mode = 'sticky', marker = '', prNumber = '', workingDir = '
 function declaredDefault(name) {
   const lines = fs.readFileSync(ACTION, 'utf8').split('\n');
   const i = lines.findIndex((l) => l.trim() === `${name}:`);
+  assert.ok(i !== -1, `input ${name} not declared in action.yml`);
   for (const l of lines.slice(i + 1)) {
     if (/^\s{2}\S/.test(l)) break;
     const m = l.match(/^\s+default:\s*"?([^"]*)"?\s*$/);


### PR DESCRIPTION
## Problem

The `terraform-plan` action's failure gate can miss a failed plan.

```yaml
- name: Terraform Plan
  id: plan
  run: |
    terraform plan ... -out=/tmp/plan.tmp
    terraform show -no-color /tmp/plan.tmp > /tmp/plan.out   # last terraform cmd in the step
  continue-on-error: true
- name: Check for Plan Failure
  if: steps.plan.outputs.exitcode == 1
```

`steps.plan.outputs.exitcode` is populated by the `setup-terraform` wrapper from the **last** terraform invocation in the step - the trailing `terraform show`, not the plan. So a plan that errored but was followed by a successful `show` reports `exitcode == 0`, the gate never fires, and `continue-on-error: true` lets the job go green on a broken plan.

(It happens to fail-closed on a fresh runner today only because a failed plan skips `-out`, so `terraform show` on the missing file also errors - i.e. correct by accident, not by design.)

## Fix

Capture the plan's own exit code explicitly and gate on that:

```yaml
run: |
  set +e
  terraform plan ... -out=/tmp/plan.tmp 2>&1 | tee /tmp/plan.raw
  code=${PIPESTATUS[0]}
  set -e
  echo "plan_exitcode=${code}" >> "$GITHUB_OUTPUT"
  if [ "$code" -eq 0 ]; then
    terraform show -no-color /tmp/plan.tmp > /tmp/plan.out
  else
    cp /tmp/plan.raw /tmp/plan.out   # keep failure output for the PR comment
  fi
- if: steps.plan.outputs.plan_exitcode != '0'
```

On failure the plan output is preserved to `/tmp/plan.out`, so the error still shows up in the PR comment instead of vanishing.

## Tests

`tests/test-plan-gate.js` extracts and executes the **real** plan-step script from `action.yml` against a fake `terraform`, asserting:
- a successful plan records `plan_exitcode=0` and renders via `terraform show`;
- a **failed** plan records its real code (`1`), not `show`'s `0`, with the failure output preserved;
- the gate expression reads `plan_exitcode` and the old wrapper-based `exitcode == 1` gate is gone.

Mutation-verified: reverting the gate to `exitcode == 1`, or capturing `show`'s exit code instead of the plan's, both fail the suite. All existing suites pass; the new one is wired into `pr-check.yml`.

## Release

Patch, `v3.0.1`. Changelog updated. No interface change - purely a correctness fix to the failure gate.

## Context

Found while migrating a multi-root consumer onto `terraform-plan@v3`: its bespoke plan used a robust `-detailed-exitcode` gate, and adopting the action as-is would have regressed that. Hardening the shared action first (rather than working around it in the consumer) so the consumer inherits a correct gate on `@v3`.
