### PR TITLE
fix(terraform-plan): keep plan artifacts in RUNNER_TEMP at 0600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v3.1.1] - 2026-07-29
+
+### Fixed
+
+- `terraform-plan` and `terraform-plan-gcp` keep their artifacts (`plan.tmp`, `plan.raw`, `plan.out`, `plan.err`, `validate_output.txt`) in `RUNNER_TEMP` at mode 0600 rather than at fixed `/tmp` paths. On a self-hosted runner two plans on one machine shared those paths - and since the scripts clean up after themselves, one job's trap could delete the file another was still reading. The rendered plan carries resource attributes and is not secret-masked, so it should not have been readable by other users on the machine either. The apply actions were fixed this way in v3.1.0; this finishes the job.
+
 ## [v3.1.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `terraform-plan` and `terraform-plan-gcp` keep their artifacts (`plan.tmp`, `plan.raw`, `plan.out`, `plan.err`, `validate_output.txt`) in `RUNNER_TEMP` at mode 0600 rather than at fixed `/tmp` paths. On a self-hosted runner two plans on one machine shared those paths - and since the scripts clean up after themselves, one job's trap could delete the file another was still reading. The rendered plan carries resource attributes and is not secret-masked, so it should not have been readable by other users on the machine either. The apply actions were fixed this way in v3.1.0; this finishes the job.
 
+### Changed
+
+- The validate step and the GCP plan step move out of `action.yml` into `scripts/validate.sh` and `scripts/gcp-plan.sh`, each shared by the two actions that ran identical copies of them. Same reasoning as `scripts/apply.sh` in v3.1.0: shellcheck'd, unit-tested, and a fix cannot land in one copy and miss the other. `terraform-plan-gcp` no longer deletes its own `plan.tmp` - the runner clears `RUNNER_TEMP` at the end of the job, so the explicit delete bought nothing once the file moved off `/tmp`.
+
 ## [v3.1.0] - 2026-07-29
 
 ### Added

--- a/actions/terraform-apply-gcp/action.yml
+++ b/actions/terraform-apply-gcp/action.yml
@@ -105,8 +105,8 @@ runs:
       id: plan
       shell: bash
       run: |
-        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out="${RUNNER_TEMP}/plan.tmp"
-        terraform show -no-color "${RUNNER_TEMP}/plan.tmp" > "${RUNNER_TEMP}/plan.out"
+        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out="${TMP}/plan.tmp"
+        terraform show -no-color "${TMP}/plan.tmp" > "${TMP}/plan.out"
       continue-on-error: true
       working-directory: ${{ inputs.working_dir }}
 
@@ -145,7 +145,7 @@ runs:
         github-token: ${{ inputs.github_token }}
         script: |
           const fs = require('fs')
-          const planPath = `${process.env.RUNNER_TEMP}/plan.out`
+          const planPath = `${process.env.RUNNER_TEMP || '/tmp'}/plan.out`
 
           let plan = fs.readFileSync(planPath, 'utf8').replace(/`/g, '\\`')
           fs.unlinkSync(planPath)

--- a/actions/terraform-apply-gcp/action.yml
+++ b/actions/terraform-apply-gcp/action.yml
@@ -104,9 +104,10 @@ runs:
     - name: Terraform Plan
       id: plan
       shell: bash
-      run: |
-        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out="${TMP}/plan.tmp"
-        terraform show -no-color "${TMP}/plan.tmp" > "${TMP}/plan.out"
+      env:
+        REFRESH: ${{ inputs.refresh }}
+      # ../../ - a composite action gets the whole repo, and the script is shared with the sibling.
+      run: bash "${GITHUB_ACTION_PATH}/../../scripts/gcp-plan.sh"
       continue-on-error: true
       working-directory: ${{ inputs.working_dir }}
 

--- a/actions/terraform-plan-gcp/action.yml
+++ b/actions/terraform-plan-gcp/action.yml
@@ -85,16 +85,18 @@ runs:
       id: validate
       shell: bash
       run: |
-        terraform validate -no-color > /tmp/validate_output.txt
+        umask 077
+        terraform validate -no-color > "${RUNNER_TEMP}/validate_output.txt"
       working-directory: ${{ inputs.working_dir }}
 
     - name: Terraform Plan
       id: plan
       shell: bash
       run: |
-        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out=/tmp/plan.tmp
-        terraform show -no-color /tmp/plan.tmp > /tmp/plan.out
-        rm -f /tmp/plan.tmp
+        umask 077
+        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out="${RUNNER_TEMP}/plan.tmp"
+        terraform show -no-color "${RUNNER_TEMP}/plan.tmp" > "${RUNNER_TEMP}/plan.out"
+        rm -f "${RUNNER_TEMP}/plan.tmp"
       continue-on-error: true
       working-directory: ${{ inputs.working_dir }}
 
@@ -112,12 +114,13 @@ runs:
         github-token: ${{ inputs.github_token }}
         script: |
           const fs = require('fs')
+          const tmp = process.env.RUNNER_TEMP || '/tmp'
 
-          const validationOutput = fs.readFileSync('/tmp/validate_output.txt', 'utf8').replace(/`/g, '\\`')
-          fs.unlinkSync('/tmp/validate_output.txt')
+          const validationOutput = fs.readFileSync(`${tmp}/validate_output.txt`, 'utf8').replace(/`/g, '\\`')
+          fs.unlinkSync(`${tmp}/validate_output.txt`)
 
-          const plan = fs.readFileSync('/tmp/plan.out', 'utf8').replace(/`/g, '\\`')
-          fs.unlinkSync('/tmp/plan.out')
+          const plan = fs.readFileSync(`${tmp}/plan.out`, 'utf8').replace(/`/g, '\\`')
+          fs.unlinkSync(`${tmp}/plan.out`)
 
           const environment = '${{ inputs.environment }}'.toUpperCase()
           const output = `#### Environment: ${environment}

--- a/actions/terraform-plan-gcp/action.yml
+++ b/actions/terraform-plan-gcp/action.yml
@@ -86,7 +86,8 @@ runs:
       shell: bash
       run: |
         umask 077
-        terraform validate -no-color > "${RUNNER_TEMP}/validate_output.txt"
+        TMP="${RUNNER_TEMP:-/tmp}"
+        terraform validate -no-color > "${TMP}/validate_output.txt"
       working-directory: ${{ inputs.working_dir }}
 
     - name: Terraform Plan
@@ -94,9 +95,10 @@ runs:
       shell: bash
       run: |
         umask 077
-        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out="${RUNNER_TEMP}/plan.tmp"
-        terraform show -no-color "${RUNNER_TEMP}/plan.tmp" > "${RUNNER_TEMP}/plan.out"
-        rm -f "${RUNNER_TEMP}/plan.tmp"
+        TMP="${RUNNER_TEMP:-/tmp}"
+        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out="${TMP}/plan.tmp"
+        terraform show -no-color "${TMP}/plan.tmp" > "${TMP}/plan.out"
+        rm -f "${TMP}/plan.tmp"
       continue-on-error: true
       working-directory: ${{ inputs.working_dir }}
 

--- a/actions/terraform-plan-gcp/action.yml
+++ b/actions/terraform-plan-gcp/action.yml
@@ -84,21 +84,17 @@ runs:
     - name: Terraform Validate
       id: validate
       shell: bash
-      run: |
-        umask 077
-        TMP="${RUNNER_TEMP:-/tmp}"
-        terraform validate -no-color > "${TMP}/validate_output.txt"
+      # ../../ - a composite action gets the whole repo, and the script is shared with the sibling.
+      run: bash "${GITHUB_ACTION_PATH}/../../scripts/validate.sh"
       working-directory: ${{ inputs.working_dir }}
 
     - name: Terraform Plan
       id: plan
       shell: bash
-      run: |
-        umask 077
-        TMP="${RUNNER_TEMP:-/tmp}"
-        terraform plan -input=false -no-color -lock=false -refresh=${{ inputs.refresh }} -out="${TMP}/plan.tmp"
-        terraform show -no-color "${TMP}/plan.tmp" > "${TMP}/plan.out"
-        rm -f "${TMP}/plan.tmp"
+      env:
+        REFRESH: ${{ inputs.refresh }}
+      # ../../ - a composite action gets the whole repo, and the script is shared with the sibling.
+      run: bash "${GITHUB_ACTION_PATH}/../../scripts/gcp-plan.sh"
       continue-on-error: true
       working-directory: ${{ inputs.working_dir }}
 

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -103,7 +103,8 @@ runs:
       id: validate
       shell: bash
       run: |
-        terraform validate -no-color > /tmp/validate_output.txt
+        umask 077
+        terraform validate -no-color > "${RUNNER_TEMP}/validate_output.txt"
       working-directory: ${{ inputs.working_dir }}
 
     - name: Terraform Plan

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -104,7 +104,8 @@ runs:
       shell: bash
       run: |
         umask 077
-        terraform validate -no-color > "${RUNNER_TEMP}/validate_output.txt"
+        TMP="${RUNNER_TEMP:-/tmp}"
+        terraform validate -no-color > "${TMP}/validate_output.txt"
       working-directory: ${{ inputs.working_dir }}
 
     - name: Terraform Plan

--- a/actions/terraform-plan/action.yml
+++ b/actions/terraform-plan/action.yml
@@ -102,10 +102,8 @@ runs:
     - name: Terraform Validate
       id: validate
       shell: bash
-      run: |
-        umask 077
-        TMP="${RUNNER_TEMP:-/tmp}"
-        terraform validate -no-color > "${TMP}/validate_output.txt"
+      # ../../ - a composite action gets the whole repo, and the script is shared with the sibling.
+      run: bash "${GITHUB_ACTION_PATH}/../../scripts/validate.sh"
       working-directory: ${{ inputs.working_dir }}
 
     - name: Terraform Plan

--- a/actions/terraform-plan/scripts/plan.sh
+++ b/actions/terraform-plan/scripts/plan.sh
@@ -6,7 +6,7 @@
 # outcome is 'failure' and the gate catches it. The plan itself is allowed to exit non-zero
 # without aborting - an error is reported through the comment, not just crashed.
 #
-# Reads: REFRESH, RUNNER_TEMP, GITHUB_OUTPUT. Writes: ${RUNNER_TEMP}/plan.out (kept for the
+# Reads: REFRESH, RUNNER_TEMP, GITHUB_OUTPUT. Writes: <RUNNER_TEMP>/plan.out (kept for the
 # comment step).
 set -euo pipefail
 

--- a/actions/terraform-plan/scripts/plan.sh
+++ b/actions/terraform-plan/scripts/plan.sh
@@ -6,21 +6,29 @@
 # outcome is 'failure' and the gate catches it. The plan itself is allowed to exit non-zero
 # without aborting - an error is reported through the comment, not just crashed.
 #
-# Reads: REFRESH, GITHUB_OUTPUT. Writes: /tmp/plan.out (kept for the comment step).
+# Reads: REFRESH, RUNNER_TEMP, GITHUB_OUTPUT. Writes: ${RUNNER_TEMP}/plan.out (kept for the
+# comment step).
 set -euo pipefail
 
-trap 'rm -f /tmp/plan.tmp /tmp/plan.raw /tmp/plan.err' EXIT
+# Per-job dir, not a fixed /tmp path: two plans on one self-hosted runner would otherwise share
+# these files, and the trap below would delete them out from under the other.
+TMP="${RUNNER_TEMP:-/tmp}"
+# The rendered plan carries resource attributes and is not secret-masked, so nothing here should
+# be readable by other users on a shared runner.
+umask 077
+
+trap 'rm -f "${TMP}/plan.tmp" "${TMP}/plan.raw" "${TMP}/plan.err"' EXIT
 
 # Capture terraform's OWN exit code via PIPESTATUS[0] - not the pipeline status, which under
 # pipefail could be tee's. set +e so a plan error doesn't abort before we read it.
 set +e
-terraform plan -input=false -no-color -lock=false -refresh="${REFRESH}" -out=/tmp/plan.tmp 2>&1 | tee /tmp/plan.raw
+terraform plan -input=false -no-color -lock=false -refresh="${REFRESH}" -out="${TMP}/plan.tmp" 2>&1 | tee "${TMP}/plan.raw"
 plan_code=${PIPESTATUS[0]}
 set -e
 echo "plan_exitcode=${plan_code}" >> "${GITHUB_OUTPUT}"
 
 if [ "${plan_code}" -ne 0 ]; then
-  cp /tmp/plan.raw /tmp/plan.out
+  cp "${TMP}/plan.raw" "${TMP}/plan.out"
   exit "${plan_code}"
 fi
 
@@ -28,8 +36,8 @@ fi
 # warnings polluting the comment); only if show fails do we append its stderr, so the error
 # still surfaces in the comment, then exit non-zero -> outcome=failure -> the gate fires.
 show_code=0
-terraform show -no-color /tmp/plan.tmp > /tmp/plan.out 2>/tmp/plan.err || show_code=$?
+terraform show -no-color "${TMP}/plan.tmp" > "${TMP}/plan.out" 2>"${TMP}/plan.err" || show_code=$?
 if [ "${show_code}" -ne 0 ]; then
-  cat /tmp/plan.err >> /tmp/plan.out
+  cat "${TMP}/plan.err" >> "${TMP}/plan.out"
   exit "${show_code}"
 fi

--- a/actions/terraform-plan/scripts/post-comment.js
+++ b/actions/terraform-plan/scripts/post-comment.js
@@ -32,9 +32,10 @@ module.exports = async ({ github, context }) => {
     return v;
   };
   const esc = (s) => s.replace(/`/g, '\\`');
-  const validationOutput = esc(consume('/tmp/validate_output.txt'));
+  const tmp = process.env.RUNNER_TEMP || '/tmp';
+  const validationOutput = esc(consume(`${tmp}/validate_output.txt`));
   // May be absent if an earlier step failed before the plan ran; post a notice rather than crash.
-  const planRaw = consume('/tmp/plan.out');
+  const planRaw = consume(`${tmp}/plan.out`);
   const plan = planRaw ? esc(planRaw) : 'Plan did not run - an earlier step failed. See the workflow logs.';
 
   // Values that render inside inline-code spans; an embedded backtick would break the span.

--- a/scripts/gcp-plan.sh
+++ b/scripts/gcp-plan.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Plan and render it for the PR comment. Shared by terraform-plan-gcp and terraform-apply-gcp,
+# which ran identical copies of this - the apply then applies the saved plan.
+#
+# Reads: REFRESH, RUNNER_TEMP. Writes: <RUNNER_TEMP>/plan.tmp, <RUNNER_TEMP>/plan.out
+set -euo pipefail
+
+# The rendered plan carries resource attributes and is not secret-masked, so it should not be
+# readable by other users on a shared runner. Per-job dir for the same reason, and because two
+# plans on one runner would otherwise share the path.
+umask 077
+TMP="${RUNNER_TEMP:-/tmp}"
+
+terraform plan -input=false -no-color -lock=false -refresh="${REFRESH}" -out="${TMP}/plan.tmp"
+terraform show -no-color "${TMP}/plan.tmp" > "${TMP}/plan.out"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Validate, keeping the output for the PR comment. Shared by terraform-plan and terraform-plan-gcp.
+#
+# Reads: RUNNER_TEMP. Writes: <RUNNER_TEMP>/validate_output.txt
+set -euo pipefail
+
+# Per-job dir at 0600, for the same reasons as the plan output - see scripts/gcp-plan.sh.
+umask 077
+terraform validate -no-color > "${RUNNER_TEMP:-/tmp}/validate_output.txt"

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -69,15 +69,22 @@ test('gate keys off the step outcome, and comment skips a pre-plan failure', () 
 // The rendered plan carries resource attributes and is not secret-masked, so a fixed path both
 // collides between concurrent jobs on a self-hosted runner and exposes it to other users there.
 test('plan artifacts live in RUNNER_TEMP, 0600, not a shared /tmp', () => {
-  for (const f of ['actions/terraform-plan/scripts/plan.sh',
+  const sources = ['actions/terraform-plan/scripts/plan.sh',
                    'actions/terraform-plan/scripts/post-comment.js',
+                   'scripts/validate.sh',
+                   'scripts/gcp-plan.sh',
                    'actions/terraform-plan/action.yml',
-                   'actions/terraform-plan-gcp/action.yml']) {
+                   'actions/terraform-plan-gcp/action.yml',
+                   'actions/terraform-apply-gcp/action.yml'];
+  for (const f of sources) {
     const src = fs.readFileSync(path.join(ROOT, f), 'utf8');
     assert.doesNotMatch(src, /\/tmp\/(plan|validate)/, `${f} still has a fixed /tmp path`);
     // Unguarded ${RUNNER_TEMP} would write to /validate_output.txt off a runner, where the
     // scripts are otherwise runnable - as the tests themselves rely on.
     assert.doesNotMatch(src, /\$\{RUNNER_TEMP\}/, `${f} uses RUNNER_TEMP without a /tmp fallback`);
+    // TMP is defined inside the scripts; a step referencing it in YAML has nothing to expand and
+    // would write to the filesystem root.
+    if (f.endsWith('.yml')) assert.doesNotMatch(src, /\$\{TMP\}/, `${f} expands TMP outside a script`);
   }
   assert.strictEqual(runPlan(0).planOutMode, '600', 'the rendered plan must not be world-readable');
 });

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -75,6 +75,9 @@ test('plan artifacts live in RUNNER_TEMP, 0600, not a shared /tmp', () => {
                    'actions/terraform-plan-gcp/action.yml']) {
     const src = fs.readFileSync(path.join(ROOT, f), 'utf8');
     assert.doesNotMatch(src, /\/tmp\/(plan|validate)/, `${f} still has a fixed /tmp path`);
+    // Unguarded ${RUNNER_TEMP} would write to /validate_output.txt off a runner, where the
+    // scripts are otherwise runnable - as the tests themselves rely on.
+    assert.doesNotMatch(src, /\$\{RUNNER_TEMP\}/, `${f} uses RUNNER_TEMP without a /tmp fallback`);
   }
   assert.strictEqual(runPlan(0).planOutMode, '600', 'the rendered plan must not be world-readable');
 });

--- a/tests/test-plan-gate.js
+++ b/tests/test-plan-gate.js
@@ -20,9 +20,11 @@ const ACTION = path.join(ROOT, 'actions', 'terraform-plan', 'action.yml');
 /** Run plan.sh with a fake terraform whose plan/show exit with the given codes. */
 function runPlan(planCode, showCode = 0) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-gate-'));
+  const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'runner-temp-'));
+  const tmpFile = f => path.join(runnerTemp, f);
   fs.writeFileSync(path.join(dir, 'terraform'), `#!/usr/bin/env bash
 case "$1" in
-  plan) [ "${planCode}" -eq 0 ] && { echo "Plan: 1 to add"; : > /tmp/plan.tmp; } || echo "Error: broke" >&2; exit ${planCode} ;;
+  plan) [ "${planCode}" -eq 0 ] && { echo "Plan: 1 to add"; : > "$RUNNER_TEMP/plan.tmp"; } || echo "Error: broke" >&2; exit ${planCode} ;;
   show) [ "${showCode}" -eq 0 ] && echo "rendered plan" || { echo "show failed" >&2; exit ${showCode}; }; exit 0 ;;
 esac
 exit 0
@@ -30,23 +32,24 @@ exit 0
   fs.chmodSync(path.join(dir, 'terraform'), 0o755);
   const outFile = path.join(dir, 'gh_output');
   fs.writeFileSync(outFile, '');
-  for (const f of ['/tmp/plan.tmp', '/tmp/plan.raw', '/tmp/plan.out']) fs.rmSync(f, { force: true });
-
   let stepFailed = false;
   try {
     execFileSync('bash', [PLAN_SH], {
       cwd: dir,
-      env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, GITHUB_OUTPUT: outFile, REFRESH: 'true' },
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, GITHUB_OUTPUT: outFile, REFRESH: 'true', RUNNER_TEMP: runnerTemp },
       stdio: 'pipe',
     });
   } catch { stepFailed = true; }
 
   const m = fs.readFileSync(outFile, 'utf8').match(/plan_exitcode=(\d+)/);
-  const planOut = fs.existsSync('/tmp/plan.out') ? fs.readFileSync('/tmp/plan.out', 'utf8') : null;
-  const tmpLeaked = fs.existsSync('/tmp/plan.tmp') || fs.existsSync('/tmp/plan.raw');
+  const planOut = fs.existsSync(tmpFile('plan.out')) ? fs.readFileSync(tmpFile('plan.out'), 'utf8') : null;
+  // The old fixed paths are checked too, so a regression back to them still reads as a leak.
+  const tmpLeaked = ['plan.tmp', 'plan.raw'].some(f => fs.existsSync(tmpFile(f)) || fs.existsSync(`/tmp/${f}`));
+  const planOutMode = fs.existsSync(tmpFile('plan.out'))
+    ? (fs.statSync(tmpFile('plan.out')).mode & 0o777).toString(8) : null;
   fs.rmSync(dir, { recursive: true, force: true });
-  for (const f of ['/tmp/plan.tmp', '/tmp/plan.raw', '/tmp/plan.out']) fs.rmSync(f, { force: true });
-  return { plan_exitcode: m ? m[1] : null, planOut, stepFailed, tmpLeaked };
+  fs.rmSync(runnerTemp, { recursive: true, force: true });
+  return { plan_exitcode: m ? m[1] : null, planOut, stepFailed, tmpLeaked, planOutMode };
 }
 
 let passed = 0, failed = 0;
@@ -61,6 +64,19 @@ test('gate keys off the step outcome, and comment skips a pre-plan failure', () 
   const a = fs.readFileSync(ACTION, 'utf8');
   assert.ok(/if:\s*steps\.plan\.outcome\s*==\s*'failure'/.test(a), 'gate must be steps.plan.outcome == failure');
   assert.ok(/steps\.plan\.outcome\s*!=\s*'skipped'/.test(a), 'comment step must skip a pre-plan failure');
+});
+
+// The rendered plan carries resource attributes and is not secret-masked, so a fixed path both
+// collides between concurrent jobs on a self-hosted runner and exposes it to other users there.
+test('plan artifacts live in RUNNER_TEMP, 0600, not a shared /tmp', () => {
+  for (const f of ['actions/terraform-plan/scripts/plan.sh',
+                   'actions/terraform-plan/scripts/post-comment.js',
+                   'actions/terraform-plan/action.yml',
+                   'actions/terraform-plan-gcp/action.yml']) {
+    const src = fs.readFileSync(path.join(ROOT, f), 'utf8');
+    assert.doesNotMatch(src, /\/tmp\/(plan|validate)/, `${f} still has a fixed /tmp path`);
+  }
+  assert.strictEqual(runPlan(0).planOutMode, '600', 'the rendered plan must not be world-readable');
 });
 
 test('plan.sh captures terraform own exit code via PIPESTATUS, not the pipeline/tee status', () => {

--- a/tests/test-refresh-configuration.js
+++ b/tests/test-refresh-configuration.js
@@ -22,16 +22,6 @@ function assertHasRefreshInput(actionPath, expectedDescriptionFragment) {
   assert.match(action, /required: false\n    default: "true"/, `${actionPath} should default refresh to true`);
 }
 
-function assertTerraformCommandUsesRefresh(actionPath, command) {
-  const action = readAction(actionPath);
-
-  assert.match(
-    action,
-    new RegExp(`${command}[^\\n]*-refresh=\\$\\{\\{ inputs\\.refresh \\}\\}`),
-    `${actionPath} should pass inputs.refresh to terraform ${command}`,
-  );
-}
-
 function runTests() {
   console.log('Running refresh configuration tests...\n');
 
@@ -43,8 +33,13 @@ function runTests() {
   const planSh = fs.readFileSync(path.join(ROOT, 'actions', 'terraform-plan', 'scripts', 'plan.sh'), 'utf8');
   assert.match(planSh, /terraform plan[^\n]*-refresh="\$\{REFRESH\}"/, 'plan.sh should pass REFRESH to terraform plan');
 
+  // Both GCP actions run the shared scripts/gcp-plan.sh, same passthrough as above.
+  const gcpPlanSh = fs.readFileSync(path.join(ROOT, 'scripts', 'gcp-plan.sh'), 'utf8');
+  assert.match(gcpPlanSh, /-refresh="\$\{REFRESH\}"/, 'gcp-plan.sh should pass REFRESH to terraform plan');
+
   assertHasRefreshInput('actions/terraform-plan-gcp/action.yml', 'Whether to refresh the state before planning');
-  assertTerraformCommandUsesRefresh('actions/terraform-plan-gcp/action.yml', 'terraform plan');
+  const planGcpAction = readAction('actions/terraform-plan-gcp/action.yml');
+  assert.match(planGcpAction, /REFRESH: \$\{\{ inputs\.refresh \}\}/, 'action.yml should pass inputs.refresh as REFRESH env');
 
   // Both apply actions run the shared scripts/apply.sh: action.yml passes inputs.refresh as the
   // REFRESH env, and the script uses it.
@@ -56,7 +51,6 @@ function runTests() {
   assert.match(applyAction, /REFRESH: \$\{\{ inputs\.refresh \}\}/, 'action.yml should pass inputs.refresh as REFRESH env');
 
   assertHasRefreshInput('actions/terraform-apply-gcp/action.yml', 'Whether to refresh the state before applying');
-  assertTerraformCommandUsesRefresh('actions/terraform-apply-gcp/action.yml', 'terraform plan');
   const applyGcpAction = readAction('actions/terraform-apply-gcp/action.yml');
   assert.match(applyGcpAction, /REFRESH: \$\{\{ inputs\.refresh \}\}/, 'action.yml should pass inputs.refresh as REFRESH env');
 


### PR DESCRIPTION
## Summary

### Why

v3.1.0 moved the apply actions' temp files to `RUNNER_TEMP` at 0600 and left the plan actions on
fixed `/tmp` paths, to keep the blast radius of a `v3`-alias move small. Same two problems remain:

- Two plans on one self-hosted runner share `plan.tmp`, `plan.raw`, `plan.out`, `plan.err` and
  `validate_output.txt`. Because the scripts clean up after themselves, one job's trap can delete a
  file the other is still reading - and `post-comment.js` then posts "Plan did not run" on a plan
  that ran fine.
- The rendered plan carries resource attributes and is not secret-masked, so it should not be
  readable by other users on the machine.

### What

- `plan.sh`, `post-comment.js` and both plan `action.yml`s derive their paths from `RUNNER_TEMP`,
  and the files are created 0600.
- The validate step and the GCP plan step move into `scripts/validate.sh` and `scripts/gcp-plan.sh`,
  each shared by the two actions that ran identical copies.
- `terraform-plan-gcp` no longer deletes its own `plan.tmp`.

### Solution

The duplication and the safety fix turned out to be the same problem. Two actions ran an identical
validate step and two ran an identical plan-and-show step, each carrying its own copy of the `umask`
and temp-dir lines - and while adding those lines I left `terraform-apply-gcp` referencing a `TMP`
its block never defined. Unset, that plan writes to `/plan.tmp` at the filesystem root and fails.
Extracting the shared scripts removes the copies and the failure mode together; no `action.yml`
defines `TMP` any more.

`plan.sh` sets `umask 077` once rather than guarding each file - it creates five across three code
paths. `RUNNER_TEMP` falls back to `/tmp` everywhere, so the scripts still run outside a runner,
which is how the tests drive them.

The `plan.tmp` delete goes away because the runner clears `RUNNER_TEMP` at the end of the job, so it
stopped earning its line once the file moved off `/tmp` - and the apply action, which needs the
file, never had it.

## Types of Changes

- [ ] ❌ Breaking change
- [ ] 🚀 New feature
- [x] 🕷 Bug fix (concurrent plans could delete each other's artifacts; an unset `TMP` in the GCP apply)
- [ ] 👏 Performance optimization
- [x] 🛠 Refactor (validate and GCP plan de-embedded to shared scripts)
- [ ] 📗 Library update
- [ ] 📝 Documentation
- [x] ✅ Test
- [x] 🔒 Security awareness (the rendered plan is no longer world-readable on a shared runner)

## Test Plan

`tests/test-plan-gate.js` runs the real `plan.sh` against a fake terraform, through `RUNNER_TEMP`.
Added: the rendered plan's mode is `600`, and across all seven touched files there may be no fixed
`/tmp/plan*` / `/tmp/validate*` path, no unguarded `${RUNNER_TEMP}`, and no `${TMP}` in YAML - the
last of which is exactly the bug above, so it cannot come back silently.

`tests/test-refresh-configuration.js` follows the extraction: every terraform invocation now lives
in a script reading `REFRESH`, so the assertions check the env passthrough plus the script, and the
now-unused inline-command helper is deleted.

```
shellcheck actions/*/scripts/*.sh scripts/*.sh tools/*.sh   # clean
node tests/*.js                                             # all 7 files pass
```

`tools/changelog-release.sh` dry run: `would release v3.1.1; move v3.1 + v3 (latest was v3.1.0)`.

Not exercised: two genuinely concurrent plans on one self-hosted runner. The collision is argued
from the shared path, not reproduced.

## Release

Patch release on merge - `v3.1.1`, with `v3.1` / `v3` moving to it. Consumers pinned to `@v3` pick it
up on their next run.

## Related Issues

- Finishes the temp-path work started in #35 / #36, which covered only the apply actions - and
  touches `terraform-apply-gcp` again, since the shared plan script is what it now runs.
