### PR TITLE
refactor(terraform-apply): let the notifier own the code fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v3.1.2] - 2026-07-30
+
+### Changed
+
+- The apply-failure notification asks `gh-actions-slack-notify` to render the error as a code block (`message_format: 'code'`, new in its v0.3.0) instead of fencing it here. `scripts/apply.sh` no longer rewrites fence terminators in the error or publishes a second, pre-fenced `slack_message` output - it publishes only `error_detail`, exactly as terraform wrote it. A Slack rendering rule does not belong in a terraform script, and escaping there mutated the value consumers of the output read. The alert renders the same; a consumer already reading `error_detail` now gets the unmodified error.
+
 ## [v3.1.1] - 2026-07-29
 
 ### Fixed

--- a/actions/terraform-apply-gcp/README.md
+++ b/actions/terraform-apply-gcp/README.md
@@ -25,7 +25,7 @@ Here are the inputs the workflow requires:
 
 | Output Name    | Description                                                                                                                                                            |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `error_detail` | The terraform error from a failed apply (from the first `Error:` block onward, capped at 2000 bytes). Empty on success. Use it to render your own failure notification. |
+| `error_detail` | The terraform error from a failed apply (from the first `Error:` block onward, capped at 2000 bytes), exactly as terraform wrote it. Empty on success. Use it to render your own failure notification. |
 
 The Slack failure notification already carries this error in its body, so an alert names the cause
 (a held state lock, a denied permission) without opening the run.

--- a/actions/terraform-apply-gcp/action.yml
+++ b/actions/terraform-apply-gcp/action.yml
@@ -122,22 +122,24 @@ runs:
       run: bash "${GITHUB_ACTION_PATH}/../../scripts/apply.sh"
 
     - name: Send Notification to Slack on success
-      uses: c0x12c/gh-actions-slack-notify@v0.2.0
+      uses: c0x12c/gh-actions-slack-notify@v0.3.0
       if: success() && inputs.slack_webhook_url != ''
       with:
         webhook_url: ${{ inputs.slack_webhook_url }}
         num-commits: ${{ inputs.num_commits }}
         title: '✅ *${{ github.event.repository.name }} - Terraform Apply SUCCESS in ${{ inputs.environment }}*'
 
-    # message is empty when the run failed before the apply, so no empty code block is posted.
     - name: Send Notification to Slack on failure
-      uses: c0x12c/gh-actions-slack-notify@v0.2.0
+      uses: c0x12c/gh-actions-slack-notify@v0.3.0
       if: failure() && inputs.slack_webhook_url != ''
       with:
         webhook_url: ${{ inputs.slack_webhook_url }}
         num-commits: ${{ inputs.num_commits }}
         title: '❌ *${{ github.event.repository.name }} - Terraform Apply FAILED in ${{ inputs.environment }}*'
-        message: ${{ steps.tf_apply.outputs.slack_message }}
+        # The action fences it and escapes any fence terminator in the error - empty when the
+        # run failed before the apply, which renders no section at all.
+        message: ${{ steps.tf_apply.outputs.error_detail }}
+        message_format: 'code'
 
     - name: Post Terraform Apply Results to PR
       uses: actions/github-script@v7

--- a/actions/terraform-apply/README.md
+++ b/actions/terraform-apply/README.md
@@ -23,7 +23,7 @@ Here are the inputs the workflow requires:
 
 | Output Name    | Description                                                                                                                                                                  |
 |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `error_detail` | The terraform error from a failed apply (from the first `Error:` block onward, capped at 2000 bytes). Empty on success. Use it to render your own failure notification. |
+| `error_detail` | The terraform error from a failed apply (from the first `Error:` block onward, capped at 2000 bytes), exactly as terraform wrote it. Empty on success. Use it to render your own failure notification. |
 
 The Slack failure notification already carries this error in its body, so an alert names the cause
 (a held state lock, a denied permission) without opening the run.

--- a/actions/terraform-apply/action.yml
+++ b/actions/terraform-apply/action.yml
@@ -102,19 +102,21 @@ runs:
       run: bash "${GITHUB_ACTION_PATH}/../../scripts/apply.sh"
 
     - name: Send Notification to Slack on success
-      uses: c0x12c/gh-actions-slack-notify@v0.2.0
+      uses: c0x12c/gh-actions-slack-notify@v0.3.0
       if: success() && inputs.slack_webhook_url != ''
       with:
         webhook_url: ${{ inputs.slack_webhook_url }}
         num-commits: ${{ inputs.num_commits }}
         title: '✅ *${{ github.event.repository.name }} - Terraform Apply SUCCESS in ${{ inputs.environment }}*'
 
-    # message is empty when the run failed before the apply, so no empty code block is posted.
     - name: Send Notification to Slack on failure
-      uses: c0x12c/gh-actions-slack-notify@v0.2.0
+      uses: c0x12c/gh-actions-slack-notify@v0.3.0
       if: failure() && inputs.slack_webhook_url != ''
       with:
         webhook_url: ${{ inputs.slack_webhook_url }}
         num-commits: ${{ inputs.num_commits }}
         title: '❌ *${{ github.event.repository.name }} - Terraform Apply FAILED in ${{ inputs.environment }}*'
-        message: ${{ steps.tf_apply.outputs.slack_message }}
+        # The action fences it and escapes any fence terminator in the error - empty when the
+        # run failed before the apply, which renders no section at all.
+        message: ${{ steps.tf_apply.outputs.error_detail }}
+        message_format: 'code'

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -4,10 +4,10 @@
 # so a fix cannot land in one and miss the other, and testable outside action.yml like plan.sh.
 #
 # Reads:  REFRESH, PLAN_FILE (optional), RUNNER_TEMP, GITHUB_OUTPUT
-# Writes: error_detail (raw), slack_message (fenced) - both empty when the apply succeeds
+# Writes: error_detail - the terraform error, empty when the apply succeeds
 set -euo pipefail
 
-# Under gh-actions-slack-notify's 2500-char cap, which would otherwise truncate the closing fence.
+# Under gh-actions-slack-notify's 2500-char cap, so the notification renders the error whole.
 MAX_ERROR_BYTES="${MAX_ERROR_BYTES:-2000}"
 
 # Per-job, not a fixed /tmp path: two applies on one self-hosted runner would share the log, and
@@ -53,8 +53,7 @@ extract_error() {
   [ -n "${detail}" ] || detail=$(tail -c "${MAX_ERROR_BYTES}" "${APPLY_LOG}" | iconv -c -f utf-8 -t utf-8)
   set -e -o pipefail
 
-  # A fence terminator would close the Slack code block early and let the rest render as mrkdwn.
-  printf '%s' "${detail//'```'/"'''"}"
+  printf '%s' "${detail}"
 }
 
 # Random delimiter, and any line matching it dropped, so error text cannot forge an output.
@@ -72,9 +71,6 @@ apply_code=0
 run_apply || apply_code=$?
 [ "${apply_code}" -eq 0 ] && exit 0
 
-error=$(extract_error)
-publish_output error_detail "${error}"
-# An empty fence would post an empty code block, so send nothing instead.
-[ -n "${error}" ] && publish_output slack_message '```'"${error}"'```'
+publish_output error_detail "$(extract_error)"
 
 exit "${apply_code}"

--- a/tests/test-apply-error-extract.js
+++ b/tests/test-apply-error-extract.js
@@ -64,7 +64,6 @@ exit ${applyCode}
   };
   const result = {
     detail: read('error_detail'),
-    slackMessage: read('slack_message'),
     args: fs.existsSync(path.join(dir, 'args')) ? fs.readFileSync(path.join(dir, 'args'), 'utf8') : '',
     // The old fixed path is checked too, so a regression back to it still reads as a leak.
     logLeaked: fs.existsSync(path.join(runnerTemp, 'apply.out')) || fs.existsSync('/tmp/apply.out'),
@@ -103,11 +102,6 @@ test('a failed apply fails the step and extracts from the first Error: block', (
   assert.ok(!r.logLeaked, 'apply output can be sensitive - it must not survive the job');
 });
 
-test('slack_message is the error in a code fence', () => {
-  const r = runApply(1, 'Error: quota exceeded\n');
-  assert.strictEqual(r.slackMessage, '```Error: quota exceeded```');
-});
-
 test('a boxed (framed) terraform error is matched too', () => {
   const r = runApply(1, 'noise\n╷\n│ Error: creating S3 Bucket: AccessDenied\n│\n╵\n');
   assert.ok(r.detail.includes('AccessDenied'), `boxed error must match, got: ${r.detail}`);
@@ -132,11 +126,12 @@ test('a failure with no Error: block falls back to the log tail', () => {
   assert.ok(r.detail && r.detail.includes('bailed out'), `expected a tail fallback, got: ${r.detail}`);
 });
 
-test('a triple backtick in the error cannot break out of the Slack code fence', () => {
+// Fencing and its escaping belong to gh-actions-slack-notify's message_format: code, so the error
+// must reach it exactly as terraform wrote it.
+test('a fence terminator in the error is passed through, not rewritten here', () => {
   const r = runApply(1, 'Error: bad value ```\nstill inside\n');
-  assert.ok(!r.detail.includes('```'), `fence terminator must be neutralized, got: ${r.detail}`);
-  assert.ok(r.slackMessage.startsWith('```') && r.slackMessage.endsWith('```'), 'exactly one fence pair');
-  assert.strictEqual(r.slackMessage.split('```').length, 3, 'no stray fence inside the block');
+  assert.ok(r.detail.includes('```'), `the renderer escapes it, this script must not, got: ${r.detail}`);
+  assert.ok(r.detail.includes('still inside'), 'the rest of the error is kept');
 });
 
 // The cap is in bytes, so it can land inside a multi-byte character - terraform's own frame is
@@ -165,9 +160,9 @@ test('printf format specifiers in the error are not interpreted', () => {
   assert.ok(r.detail.includes('%s expected %d'), `format specifiers stay literal, got: ${r.detail}`);
 });
 
-test('a failure with nothing to report publishes no empty code block', () => {
+test('a failure with nothing to report publishes an empty detail, not a stray marker', () => {
   const r = runApply(3, '');
-  assert.strictEqual(r.slackMessage, null, 'an empty fence would post an empty code block');
+  assert.strictEqual(r.detail, '', 'an empty message renders no Slack section at all');
 });
 
 test('an error containing the heredoc delimiter cannot forge an output', () => {
@@ -210,8 +205,9 @@ for (const action of ACTIONS) {
 
   test(label('exports the error and puts it in the failure notification'), () => {
     assert.match(yml, /value: \$\{\{ steps\.tf_apply\.outputs\.error_detail \}\}/, 'error_detail must be an action output');
-    assert.match(yml, /message: \$\{\{ steps\.tf_apply\.outputs\.slack_message \}\}/, 'failure notification carries the error');
-    assert.match(yml, /gh-actions-slack-notify@v0\.2\.0/, 'the message input needs slack-notify >= v0.2.0');
+    assert.match(yml, /message: \$\{\{ steps\.tf_apply\.outputs\.error_detail \}\}/, 'failure notification carries the error');
+    assert.match(yml, /message_format: 'code'/, 'the renderer owns the fence and its escaping');
+    assert.match(yml, /gh-actions-slack-notify@v0\.3\.0/, 'message_format needs slack-notify >= v0.3.0');
   });
 
   // The commit list came from slack-notify's own default before, so it was invisible here and


### PR DESCRIPTION
## Summary

### Why

The Slack code fence and its escaping lived in `scripts/apply.sh`: it rewrote every fence terminator
in terraform's error and published a second, pre-fenced `slack_message` output beside the raw one.

Two problems with that. A Slack rendering rule does not belong in a terraform script - any other
caller wanting a code block would repeat the same escaping. And it meant `error_detail`, the output
a consumer reads to render its own notification, was not quite what terraform wrote.

### What

`gh-actions-slack-notify` v0.3.0 added `message_format`, so the failure step asks for a code block
and hands over the error untouched.

- `scripts/apply.sh` publishes only `error_detail`, exactly as terraform wrote it.
- Both apply actions pin `gh-actions-slack-notify@v0.3.0` and pass `message_format: 'code'`.

### Solution

The escaping moves to the renderer, which is the only place that knows the rule: Slack closes a code
block at the first fence terminator. The action now handles that, drops trailing backticks that
would merge with the closing fence, and reserves the fence inside its own character cap - so this
script no longer needs the 2000-byte margin for fence overhead either, though it keeps it as
headroom under the 2500 cap.

The rendered alert is unchanged. What changes for a consumer already reading `error_detail` is that
it now gets the unmodified error.

The tests followed the responsibility rather than being deleted: where they asserted a fence
terminator was neutralized *here*, they now assert it survives to reach the renderer.

## Types of Changes

- [ ] ❌ Breaking change
- [ ] 🚀 New feature
- [ ] 🕷 Bug fix
- [ ] 👏 Performance optimization
- [x] 🛠 Refactor (fence handling moves to the notifier)
- [x] 📗 Library update (slack-notify `v0.2.0` -> `v0.3.0`)
- [x] 📝 Documentation
- [x] ✅ Test
- [ ] 🔒 Security awareness

## Test Plan

```
shellcheck actions/*/scripts/*.sh scripts/*.sh tools/*.sh   # clean
node tests/*.js                                             # all 7 files pass
```

Verified before pinning that the `v0.3.0` tag's committed `dist/index.js` actually carries the
`message_format` handling - a stale bundle in that repo would make this a silent no-op, which is the
classic failure mode for a committed-`dist` action.

Not exercised: the rendered Slack message. The tests assert what this script publishes; how the
action renders it is asserted in that repo's own suite, and how Slack displays it is worth
eyeballing on the first real failed apply.

## Release

Patch release on merge - `v3.1.2`, with `v3.1` / `v3` moving to it. Dry run:
`would release v3.1.2; move v3.1 + v3 (latest was v3.1.1)`.

## Related Issues

- Requires `c0x12c/gh-actions-slack-notify` #13 (released as v0.3.0), which is already merged.
